### PR TITLE
Add leading slash to api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,6 @@ __debug_*
 local.go
 resolver.go
 
-api
+/api
 
 *.pem

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __debug_*
 local.go
 resolver.go
 
-/api
+api
+!internal/api
 
 *.pem


### PR DESCRIPTION
`api` will match everything in the ./api/directory as well as the binary, causing any new files created to be ignored by default