### PR TITLE
feature: Import/Export dashboards for seeding

### DIFF
--- a/cmd/dashboards/dashboards.go
+++ b/cmd/dashboards/dashboards.go
@@ -1,0 +1,17 @@
+package dashboards
+
+import "github.com/spf13/cobra"
+
+var (
+	RootCmd = &cobra.Command{
+		Use:   "dashboards",
+		Short: "Dashboard related commands",
+	}
+)
+
+func init() {
+	// export
+	RootCmd.AddCommand(newImportCMD())
+	// import
+	RootCmd.AddCommand(newDashboardsImportCMD())
+}

--- a/cmd/dashboards/export.go
+++ b/cmd/dashboards/export.go
@@ -1,0 +1,106 @@
+package dashboards
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/compliance-framework/api/internal/config"
+	"github.com/compliance-framework/api/internal/converters/labelfilter"
+	"github.com/compliance-framework/api/internal/service"
+	"github.com/compliance-framework/api/internal/service/relational"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+type controlRef struct {
+	CatalogID uuid.UUID `json:"catalog_id,omitempty"`
+	ID        string    `json:"id,omitempty"`
+}
+
+type dashboardJSON struct {
+	Name     string              `json:"name,omitempty"`
+	Filter   *labelfilter.Filter `json:"filter"`
+	Controls []controlRef        `json:"controls,omitempty"`
+}
+
+func newImportCMD() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export dashboards from the system",
+		Long:  "This command allows you to export dashboards from the compliance framework configuration service.",
+		Run:   exportDashboards,
+	}
+
+	cmd.Flags().StringP("output", "o", "dashboards_export.json", "Output file for exported dashboards")
+	cmd.MarkFlagRequired("output")
+
+	return cmd
+}
+
+func exportDashboards(cmd *cobra.Command, args []string) {
+	zapLogger, err := zap.NewProduction()
+	if err != nil {
+		log.Fatalf("Can't initialize zap logger: %v", err)
+	}
+	sugar := zapLogger.Sugar()
+	defer zapLogger.Sync() // flushes buffer, if any
+
+	config := config.NewConfig(sugar)
+
+	outputFile, err := cmd.Flags().GetString("output")
+	if err != nil {
+		panic(err)
+	}
+
+	db, err := service.ConnectSQLDb(context.Background(), config, sugar)
+	if err != nil {
+		panic("failed to connect database")
+	}
+
+	var dashboards []relational.Filter
+	if err := db.
+		Select("id", "name", "filter").
+		Preload("Controls", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id", "catalog_id")
+		}).
+		Find(&dashboards).Error; err != nil {
+		sugar.Fatalf("failed to fetch dashboards: %v", err)
+	}
+
+	file, err := os.Create(outputFile)
+	if err != nil {
+		sugar.Fatalf("failed to create output file: %v", err)
+	}
+	defer file.Close()
+
+	// Map to export DTOs to omit empty/null values and Filter.ID
+	exports := make([]dashboardJSON, 0, len(dashboards))
+	for _, f := range dashboards {
+		fe := dashboardJSON{
+			Name: f.Name,
+		}
+		// Extract underlying filter and omit if empty
+		lf := f.Filter.Data()
+		fe.Filter = &lf
+		if len(f.Controls) > 0 {
+			ctrls := make([]controlRef, len(f.Controls))
+			for i, c := range f.Controls {
+				ctrls[i] = controlRef{CatalogID: c.CatalogID, ID: c.ID}
+			}
+			fe.Controls = ctrls
+		}
+		exports = append(exports, fe)
+	}
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(exports); err != nil {
+		sugar.Fatalf("failed to write dashboards to file: %v", err)
+	}
+
+	sugar.Infof("Successfully exported %d dashboards to %s", len(dashboards), outputFile)
+}

--- a/cmd/dashboards/import.go
+++ b/cmd/dashboards/import.go
@@ -1,0 +1,100 @@
+package dashboards
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/compliance-framework/api/internal/config"
+	"github.com/compliance-framework/api/internal/converters/labelfilter"
+	"github.com/compliance-framework/api/internal/service"
+	"github.com/compliance-framework/api/internal/service/relational"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"gorm.io/datatypes"
+)
+
+func newDashboardsImportCMD() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import",
+		Short: "Import dashboard filters from JSON",
+		Long:  "Reads a JSON array of filters and creates Filter records and their control relations.",
+		Run:   importDashboards,
+	}
+
+	cmd.Flags().StringP("file", "f", "", "Input JSON file containing filters")
+	cmd.MarkFlagRequired("file")
+
+	return cmd
+}
+
+func importDashboards(cmd *cobra.Command, args []string) {
+	zapLogger, err := zap.NewProduction()
+	if err != nil {
+		log.Fatalf("Can't initialize zap logger: %v", err)
+	}
+	sugar := zapLogger.Sugar()
+	defer zapLogger.Sync()
+
+	cfg := config.NewConfig(sugar)
+
+	inputFile, err := cmd.Flags().GetString("file")
+	if err != nil {
+		panic(err)
+	}
+
+	db, err := service.ConnectSQLDb(context.Background(), cfg, sugar)
+	if err != nil {
+		panic("failed to connect database")
+	}
+
+	// Read and decode input JSON
+	f, err := os.Open(inputFile)
+	if err != nil {
+		sugar.Fatalf("failed to open input file: %v", err)
+	}
+	defer f.Close()
+
+	var inputs []dashboardJSON
+	if err := json.NewDecoder(f).Decode(&inputs); err != nil {
+		sugar.Fatalf("failed to decode input JSON: %v", err)
+	}
+
+	created := 0
+	for _, in := range inputs {
+		rec := relational.Filter{
+			Name: in.Name,
+		}
+
+		// Build filter JSON if provided
+		if in.Filter != nil {
+			lf := labelfilter.Filter{Scope: in.Filter.Scope}
+			rec.Filter = datatypes.NewJSONType(lf)
+		}
+
+		if err := db.Create(&rec).Error; err != nil {
+			sugar.Fatalf("failed to create filter '%s': %v", in.Name, err)
+		}
+
+		// Resolve and link controls if provided
+		if len(in.Controls) > 0 {
+			controls := make([]relational.Control, 0, len(in.Controls))
+			for _, cr := range in.Controls {
+				var ctl relational.Control
+				if err := db.Where("catalog_id = ? AND id = ?", cr.CatalogID, cr.ID).First(&ctl).Error; err != nil {
+					sugar.Fatalf("control not found for catalog '%s' id '%s': %v", cr.CatalogID, cr.ID, err)
+				}
+				controls = append(controls, ctl)
+			}
+			if err := db.Model(&rec).Association("Controls").Replace(controls); err != nil {
+				sugar.Fatalf("failed linking controls for filter '%s': %v", in.Name, err)
+			}
+		}
+
+		created++
+		sugar.Infow("Created filter", "name", rec.Name)
+	}
+
+	sugar.Infof("Successfully imported %d filters from %s", created, inputFile)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/compliance-framework/api/cmd/dashboards"
 	"github.com/compliance-framework/api/cmd/oscal"
 	"github.com/compliance-framework/api/cmd/seed"
 	"github.com/compliance-framework/api/cmd/users"
@@ -61,6 +62,7 @@ func init() {
 	rootCmd.AddCommand(users.RootCmd)
 	rootCmd.AddCommand(seed.RootCmd)
 	rootCmd.AddCommand(newMigrateCMD())
+	rootCmd.AddCommand(dashboards.RootCmd)
 }
 
 func Execute() error {

--- a/internal/api/handler/oscal/system_security_plans_test.go
+++ b/internal/api/handler/oscal/system_security_plans_test.go
@@ -818,13 +818,12 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestDeleteImplementedRequire
 				StatementId: "ac-1_stmt.a",
 				Remarks:     "Initial statement implementation",
 				ByComponents: &[]oscalTypes_1_1_3.ByComponent{
-			{
-				UUID: byComponentUuid,
-				Description: "Test By Component",
-				ComponentUuid: componentUuid,
-			},
-
-			},
+					{
+						UUID:          byComponentUuid,
+						Description:   "Test By Component",
+						ComponentUuid: componentUuid,
+					},
+				},
 			},
 		},
 	}
@@ -858,10 +857,8 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestDeleteImplementedRequire
 	resp = httptest.NewRecorder()
 	server.E().ServeHTTP(resp, req)
 
-
 	suite.Equal(http.StatusNotFound, resp.Code)
 }
-
 
 // Test creating a by-component within a statement within an implemented requirement
 func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateImplementedRequirementStatementByComponent() {
@@ -899,13 +896,12 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateImplementedRequire
 				StatementId: "ac-1_stmt.a",
 				Remarks:     "Initial statement implementation",
 				ByComponents: &[]oscalTypes_1_1_3.ByComponent{
-			{
-				UUID: uuid.New().String(),
-				Description: "Test By Component",
-				ComponentUuid: componentUuid,
-			},
-
-			},
+					{
+						UUID:          uuid.New().String(),
+						Description:   "Test By Component",
+						ComponentUuid: componentUuid,
+					},
+				},
 			},
 		},
 	}
@@ -932,9 +928,9 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateImplementedRequire
 
 	newByComponent := oscalTypes_1_1_3.ByComponent{
 		ComponentUuid: firstByComponent.ComponentUuid,
-		UUID: uuid.New().String(),
-		Description: "New ByComponent",
-		Remarks: "New by-component with new remarks",
+		UUID:          uuid.New().String(),
+		Description:   "New ByComponent",
+		Remarks:       "New by-component with new remarks",
 		Props: &[]oscalTypes_1_1_3.Property{
 			{
 				Name:  "new-prop",
@@ -955,7 +951,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateImplementedRequire
 			},
 		},
 		ImplementationStatus: &oscalTypes_1_1_3.ImplementationStatus{
-			State: "Implemented",
+			State:   "Implemented",
 			Remarks: "Test Remarks",
 		},
 	}
@@ -971,7 +967,6 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateImplementedRequire
 	err = json.Unmarshal(resp.Body.Bytes(), &createBCResponse)
 	suite.NoError(err)
 }
-
 
 // Test updating a statement with invalid IDs
 func (suite *SystemSecurityPlanApiIntegrationSuite) TestUpdateImplementedRequirementStatementInvalidIDs() {

--- a/internal/service/relational/system_security_plan.go
+++ b/internal/service/relational/system_security_plan.go
@@ -1399,21 +1399,20 @@ func (is *ImplementationStatus) MarshalOscal() *oscalTypes_1_1_3.ImplementationS
 }
 
 func ConvertOscalToImplementationStatus(oscal *oscalTypes_1_1_3.ImplementationStatus) datatypes.JSONType[ImplementationStatus] {
-    impStatus := ImplementationStatus{
-        State: oscal.State,
-        Remarks: oscal.Remarks,
-    }
+	impStatus := ImplementationStatus{
+		State:   oscal.State,
+		Remarks: oscal.Remarks,
+	}
 	return datatypes.NewJSONType(impStatus)
 }
 
-func ConvertImplementationStatusToOscal(data datatypes.JSONType[ImplementationStatus]) *oscalTypes_1_1_3.ImplementationStatus  {
-    impStatus := oscalTypes_1_1_3.ImplementationStatus{
-		State: data.Data().State,
+func ConvertImplementationStatusToOscal(data datatypes.JSONType[ImplementationStatus]) *oscalTypes_1_1_3.ImplementationStatus {
+	impStatus := oscalTypes_1_1_3.ImplementationStatus{
+		State:   data.Data().State,
 		Remarks: data.Data().Remarks,
 	}
 	return &impStatus
 }
-
 
 type Export struct {
 	UUIDModel


### PR DESCRIPTION
This pull request introduces a new CLI command group for dashboard management, adding functionality to export and import dashboard filters and their associated controls to and from JSON files. Additionally, it integrates these commands into the root CLI and makes minor code cleanup in test files.

New dashboard CLI features:

* Added a new `dashboards` command group with `export` and `import` subcommands for managing dashboard filters and control associations. (`cmd/dashboards/dashboards.go`)
* Implemented the `export` command to serialize dashboard filters and their controls from the database into a JSON file. (`cmd/dashboards/export.go`)
* Implemented the `import` command to read dashboard filter definitions from a JSON file and populate the database, including control associations. (`cmd/dashboards/import.go`)

CLI integration:

* Registered the new `dashboards` command group in the root CLI, making it available to users. (`cmd/root.go`) [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR8) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR65)