### PR TITLE
Feat/bch synchronous orphaned risk cleanup

### DIFF
--- a/cmd/profile_control_resolver.go
+++ b/cmd/profile_control_resolver.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	oscalhandler "github.com/compliance-framework/api/internal/api/handler/oscal"
+	riskrel "github.com/compliance-framework/api/internal/service/relational/risks"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// oscalProfileControlResolver implements worker.ProfileControlResolver using the oscal handler
+// package's profile resolution functions. It lives in the cmd package to break the circular
+// import that would result from importing the oscal handler directly from the worker package.
+//
+// Resolution strategy:
+//  1. Fast path — query the profile_controls pivot table (populated by SyncProfileControls).
+//     Returns both control_id and control_catalog_id so the full ControlKey is available.
+//  2. Fallback — if the pivot table is empty (SyncProfileControls has not yet run for a
+//     newly created profile), perform a full recursive resolution via FindFullProfile and
+//     GetControlIDsMapFromProfile. This guarantees correctness even before the pivot is populated.
+type oscalProfileControlResolver struct {
+	db *gorm.DB
+}
+
+func (r *oscalProfileControlResolver) ResolveProfileControlKeys(ctx context.Context, profileID uuid.UUID) ([]riskrel.ControlKey, error) {
+	// Step 1: pivot table fast path.
+	type pivotRow struct {
+		ControlCatalogID string `gorm:"column:control_catalog_id"`
+		ControlID        string `gorm:"column:control_id"`
+	}
+	var rows []pivotRow
+	if err := r.db.WithContext(ctx).
+		Table("profile_controls").
+		Select("control_catalog_id, control_id").
+		Where("profile_id = ?", profileID).
+		Find(&rows).Error; err == nil && len(rows) > 0 {
+		keys := make([]riskrel.ControlKey, 0, len(rows))
+		for _, row := range rows {
+			keys = append(keys, riskrel.ControlKey{
+				CatalogID: row.ControlCatalogID,
+				ControlID: row.ControlID,
+			})
+		}
+		return keys, nil
+	}
+
+	// Step 2: full recursive resolution — pivot table is empty or query failed.
+	profile, err := oscalhandler.FindFullProfile(r.db.WithContext(ctx), profileID)
+	if err != nil {
+		return nil, fmt.Errorf("oscalProfileControlResolver: FindFullProfile failed for profile %s: %w", profileID, err)
+	}
+
+	idsMap, err := oscalhandler.GetControlIDsMapFromProfile(profile, r.db.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("oscalProfileControlResolver: GetControlIDsMapFromProfile failed for profile %s: %w", profileID, err)
+	}
+
+	keys := make([]riskrel.ControlKey, 0, len(idsMap))
+	for controlID, catalogID := range idsMap {
+		keys = append(keys, riskrel.ControlKey{
+			CatalogID: catalogID.String(),
+			ControlID: controlID,
+		})
+	}
+	return keys, nil
+}

--- a/cmd/profile_control_resolver.go
+++ b/cmd/profile_control_resolver.go
@@ -28,8 +28,8 @@ type oscalProfileControlResolver struct {
 func (r *oscalProfileControlResolver) ResolveProfileControlKeys(ctx context.Context, profileID uuid.UUID) ([]riskrel.ControlKey, error) {
 	// Step 1: pivot table fast path.
 	type pivotRow struct {
-		ControlCatalogID string `gorm:"column:control_catalog_id"`
-		ControlID        string `gorm:"column:control_id"`
+		ControlCatalogID uuid.UUID `gorm:"column:control_catalog_id"`
+		ControlID        string    `gorm:"column:control_id"`
 	}
 	var rows []pivotRow
 	if err := r.db.WithContext(ctx).
@@ -43,7 +43,7 @@ func (r *oscalProfileControlResolver) ResolveProfileControlKeys(ctx context.Cont
 		keys := make([]riskrel.ControlKey, 0, len(rows))
 		for _, row := range rows {
 			keys = append(keys, riskrel.ControlKey{
-				CatalogID: row.ControlCatalogID,
+				CatalogID: row.ControlCatalogID.String(),
 				ControlID: row.ControlID,
 			})
 		}

--- a/cmd/profile_control_resolver.go
+++ b/cmd/profile_control_resolver.go
@@ -17,9 +17,10 @@ import (
 // Resolution strategy:
 //  1. Fast path — query the profile_controls pivot table (populated by SyncProfileControls).
 //     Returns both control_id and control_catalog_id so the full ControlKey is available.
-//  2. Fallback — if the pivot table is empty (SyncProfileControls has not yet run for a
-//     newly created profile), perform a full recursive resolution via FindFullProfile and
-//     GetControlIDsMapFromProfile. This guarantees correctness even before the pivot is populated.
+//  2. Fallback — if the pivot table query succeeds but returns no rows (SyncProfileControls
+//     has not yet run for a newly created profile), perform a full recursive resolution via
+//     FindFullProfile and GetControlIDsMapFromProfile. This guarantees correctness even before
+//     the pivot is populated without masking real database errors.
 type oscalProfileControlResolver struct {
 	db *gorm.DB
 }
@@ -35,7 +36,10 @@ func (r *oscalProfileControlResolver) ResolveProfileControlKeys(ctx context.Cont
 		Table("profile_controls").
 		Select("control_catalog_id, control_id").
 		Where("profile_id = ?", profileID).
-		Find(&rows).Error; err == nil && len(rows) > 0 {
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("oscalProfileControlResolver: profile_controls query failed for profile %s: %w", profileID, err)
+	}
+	if len(rows) > 0 {
 		keys := make([]riskrel.ControlKey, 0, len(rows))
 		for _, row := range rows {
 			keys = append(keys, riskrel.ControlKey{
@@ -46,7 +50,7 @@ func (r *oscalProfileControlResolver) ResolveProfileControlKeys(ctx context.Cont
 		return keys, nil
 	}
 
-	// Step 2: full recursive resolution — pivot table is empty or query failed.
+	// Step 2: full recursive resolution — pivot table is empty.
 	profile, err := oscalhandler.FindFullProfile(r.db.WithContext(ctx), profileID)
 	if err != nil {
 		return nil, fmt.Errorf("oscalProfileControlResolver: FindFullProfile failed for profile %s: %w", profileID, err)

--- a/cmd/profile_control_resolver_test.go
+++ b/cmd/profile_control_resolver_test.go
@@ -34,10 +34,11 @@ func TestOscalProfileControlResolver_ReturnsPivotRows(t *testing.T) {
 	`).Error)
 
 	profileID := uuid.New()
+	catalogID := uuid.New()
 	require.NoError(t, db.Exec(
 		"INSERT INTO profile_controls (profile_id, control_catalog_id, control_id) VALUES (?, ?, ?)",
 		profileID.String(),
-		"catalog-1",
+		catalogID.String(),
 		"AC-1",
 	).Error)
 
@@ -46,6 +47,6 @@ func TestOscalProfileControlResolver_ReturnsPivotRows(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
-	assert.Equal(t, "catalog-1", keys[0].CatalogID)
+	assert.Equal(t, catalogID.String(), keys[0].CatalogID)
 	assert.Equal(t, "AC-1", keys[0].ControlID)
 }

--- a/cmd/profile_control_resolver_test.go
+++ b/cmd/profile_control_resolver_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestOscalProfileControlResolver_ReturnsPivotQueryError(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	resolver := &oscalProfileControlResolver{db: db}
+	_, err = resolver.ResolveProfileControlKeys(context.Background(), uuid.New())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "profile_controls query failed")
+}
+
+func TestOscalProfileControlResolver_ReturnsPivotRows(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		CREATE TABLE profile_controls (
+			profile_id TEXT NOT NULL,
+			control_catalog_id TEXT NOT NULL,
+			control_id TEXT NOT NULL
+		)
+	`).Error)
+
+	profileID := uuid.New()
+	require.NoError(t, db.Exec(
+		"INSERT INTO profile_controls (profile_id, control_catalog_id, control_id) VALUES (?, ?, ?)",
+		profileID.String(),
+		"catalog-1",
+		"AC-1",
+	).Error)
+
+	resolver := &oscalProfileControlResolver{db: db}
+	keys, err := resolver.ResolveProfileControlKeys(context.Background(), profileID)
+
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "catalog-1", keys[0].CatalogID)
+	assert.Equal(t, "AC-1", keys[0].ControlID)
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -152,7 +152,7 @@ func RunServer(cmd *cobra.Command, args []string) {
 	}
 
 	handler.RegisterHandlers(server, sugar, db, cfg, services)
-	oscal.RegisterHandlers(server, sugar, db, cfg, evidenceService)
+	oscal.RegisterHandlers(server, sugar, db, cfg, evidenceService, workerService)
 	auth.RegisterHandlers(server, sugar, db, cfg, metrics, emailService, workerService)
 
 	sugar.Infow("Allowed Origins", "origins", cfg.APIAllowedOrigins)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -99,8 +99,13 @@ func RunServer(cmd *cobra.Command, args []string) {
 	// Initialize digest service (without worker service initially)
 	digestService := digest.NewService(db, emailService, slackService, nil, cfg, sugar)
 
+	// profileResolver bridges the worker package and the oscal handler package without creating
+	// a circular import. It uses the pivot table fast path first, then falls back to full
+	// recursive profile resolution via oscal.FindFullProfile / oscal.GetControlIDsMapFromProfile.
+	profileResolver := &oscalProfileControlResolver{db: db}
+
 	// Initialize worker service with digest support
-	workerService, err := worker.NewServiceWithDigest(cfg.Worker, db, emailService, digestService, cfg, sugar)
+	workerService, err := worker.NewServiceWithDigest(cfg.Worker, db, emailService, digestService, cfg, profileResolver, sugar)
 	if err != nil {
 		sugar.Fatalw("Failed to initialize worker service", "error", err)
 	}

--- a/internal/api/handler/oscal/activity_integration_test.go
+++ b/internal/api/handler/oscal/activity_integration_test.go
@@ -39,7 +39,7 @@ func (suite *ActivityApiIntegrationSuite) SetupSuite() {
 	metrics := api.NewMetricsHandler(context.Background(), suite.logger)
 	suite.server = api.NewServer(context.Background(), suite.logger, suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, suite.logger, suite.Config, nil)
-	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc, nil)
 }
 
 func (suite *ActivityApiIntegrationSuite) SetupTest() {

--- a/internal/api/handler/oscal/api.go
+++ b/internal/api/handler/oscal/api.go
@@ -9,7 +9,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func RegisterHandlers(server *api.Server, logger *zap.SugaredLogger, db *gorm.DB, config *config.Config, evidenceSvc *evidencesvc.EvidenceService) {
+func RegisterHandlers(server *api.Server, logger *zap.SugaredLogger, db *gorm.DB, config *config.Config, evidenceSvc *evidencesvc.EvidenceService, jobEnqueuer SSPJobEnqueuer) {
 	oscalGroup := server.API().Group("/oscal")
 	oscalGroup.Use(middleware.JWTMiddleware(config.JWTPublicKey))
 
@@ -19,7 +19,7 @@ func RegisterHandlers(server *api.Server, logger *zap.SugaredLogger, db *gorm.DB
 	profileHandler := NewProfileHandler(logger, db)
 	profileHandler.Register(oscalGroup.Group("/profiles"))
 
-	sspHandler := NewSystemSecurityPlanHandler(logger, db, evidenceSvc)
+	sspHandler := NewSystemSecurityPlanHandler(logger, db, evidenceSvc, jobEnqueuer)
 	sspHandler.Register(oscalGroup.Group("/system-security-plans"))
 
 	partyHandler := NewPartyHandler(logger, db)

--- a/internal/api/handler/oscal/assessment_results_integration_test.go
+++ b/internal/api/handler/oscal/assessment_results_integration_test.go
@@ -44,7 +44,7 @@ func (suite *AssessmentResultsApiIntegrationSuite) SetupSuite() {
 	metrics := api.NewMetricsHandler(context.Background(), suite.logger)
 	suite.server = api.NewServer(context.Background(), suite.logger, suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, suite.logger, suite.Config, nil)
-	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc, nil)
 }
 
 func (suite *AssessmentResultsApiIntegrationSuite) SetupTest() {

--- a/internal/api/handler/oscal/assessmentplan_integration_test.go
+++ b/internal/api/handler/oscal/assessmentplan_integration_test.go
@@ -53,7 +53,7 @@ func (suite *AssessmentPlanApiIntegrationSuite) SetupSuite() {
 	}
 	handler.RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, services)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, suite.logger, suite.Config, nil)
-	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc, nil)
 }
 
 func (suite *AssessmentPlanApiIntegrationSuite) SetupTest() {

--- a/internal/api/handler/oscal/asset_integration_test.go
+++ b/internal/api/handler/oscal/asset_integration_test.go
@@ -42,7 +42,7 @@ func (suite *AssetApiIntegrationSuite) SetupSuite() {
 	metrics := api.NewMetricsHandler(context.Background(), suite.logger)
 	suite.server = api.NewServer(context.Background(), suite.logger, suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, suite.logger, suite.Config, nil)
-	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc, nil)
 }
 
 func (suite *AssetApiIntegrationSuite) SetupTest() {

--- a/internal/api/handler/oscal/catalogs_integration_test.go
+++ b/internal/api/handler/oscal/catalogs_integration_test.go
@@ -49,7 +49,7 @@ func (suite *CatalogApiIntegrationSuite) TestDuplicateCatalogGroupID() {
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create two catalogs with the same group ID structure
 	catalogs := []oscaltypes.Catalog{
@@ -147,7 +147,7 @@ func (suite *CatalogApiIntegrationSuite) TestDuplicateCatalogControlID() {
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create two catalogs with the same group ID structure
 	catalogs := []oscaltypes.Catalog{
@@ -244,7 +244,7 @@ func (suite *CatalogApiIntegrationSuite) TestDuplicateCatalogChildControlID() {
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create two catalogs with the same group ID structure
 	catalogs := []oscaltypes.Catalog{
@@ -339,7 +339,7 @@ func (suite *CatalogApiIntegrationSuite) TestRootGroup() {
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create two catalogs with the same group ID structure
 	catalog := oscaltypes.Catalog{
@@ -401,7 +401,7 @@ func (suite *CatalogApiIntegrationSuite) TestRootControl() {
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create two catalogs with the same group ID structure
 	catalog := oscaltypes.Catalog{
@@ -462,7 +462,7 @@ func (suite *CatalogApiIntegrationSuite) TestCascadeDeleteGroupRemovesControls()
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	catalog := oscaltypes.Catalog{
 		UUID: "D5A6E1FF-7F21-4B3C-A2B7-998877665544",
@@ -546,7 +546,7 @@ func (suite *CatalogApiIntegrationSuite) TestCascadeDeleteControlRemovesChildren
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	catalog := oscaltypes.Catalog{
 		UUID: "A1B2C3D4-E5F6-4711-8899-112233445566",
@@ -606,7 +606,7 @@ func (suite *CatalogApiIntegrationSuite) TestCascadeDeleteCatalogRemovesEverythi
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	catalog := oscaltypes.Catalog{
 		UUID: "F0E1D2C3-B4A5-6789-ABCD-001122334455",
@@ -670,7 +670,7 @@ func (suite *CatalogApiIntegrationSuite) TestFilterControlsCatalogScopedDelete()
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create two catalogs with the same control ID
 	catA := oscaltypes.Catalog{

--- a/internal/api/handler/oscal/component_definition_integration_test.go
+++ b/internal/api/handler/oscal/component_definition_integration_test.go
@@ -45,7 +45,7 @@ func (suite *ComponentDefinitionApiIntegrationSuite) SetupSuite() {
 	metrics := api.NewMetricsHandler(context.Background(), suite.logger)
 	suite.server = api.NewServer(context.Background(), suite.logger, suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, suite.logger, suite.Config, nil)
-	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc, nil)
 	fmt.Println("Server initialized")
 }
 

--- a/internal/api/handler/oscal/inventory_integration_test.go
+++ b/internal/api/handler/oscal/inventory_integration_test.go
@@ -41,7 +41,7 @@ func (suite *InventoryApiIntegrationSuite) SetupSuite() {
 	logger := zap.NewNop().Sugar()
 	suite.handler = NewInventoryHandler(logger, suite.DB)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger, suite.Config, nil)
-	suite.sspHandler = NewSystemSecurityPlanHandler(logger, suite.DB, evidenceSvc)
+	suite.sspHandler = NewSystemSecurityPlanHandler(logger, suite.DB, evidenceSvc, nil)
 	suite.poamHandler = NewPlanOfActionAndMilestonesHandler(logger, suite.DB)
 	suite.evidenceHandler = handler.NewEvidenceHandler(logger, evidenceSvc)
 

--- a/internal/api/handler/oscal/plan_of_action_and_milestones_integration_test.go
+++ b/internal/api/handler/oscal/plan_of_action_and_milestones_integration_test.go
@@ -45,7 +45,7 @@ func (suite *PlanOfActionAndMilestonesApiIntegrationSuite) SetupSuite() {
 	metrics := api.NewMetricsHandler(context.Background(), suite.logger)
 	suite.server = api.NewServer(context.Background(), suite.logger, suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, suite.logger, suite.Config, nil)
-	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc, nil)
 	fmt.Println("Server initialized")
 }
 

--- a/internal/api/handler/oscal/profiles_integration_test.go
+++ b/internal/api/handler/oscal/profiles_integration_test.go
@@ -62,7 +62,7 @@ func (suite *ProfileIntegrationSuite) SetupSuite() {
 	suite.logger = logger.Sugar()
 	metrics := api.NewMetricsHandler(context.Background(), suite.logger)
 	suite.server = api.NewServer(context.Background(), suite.logger, suite.Config, metrics)
-	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, nil)
+	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, nil, nil)
 
 	profileFp, err := os.Open("../../../../testdata/profile_fedramp_low.json")
 	suite.Require().NoError(err, "Failed to open profile file")

--- a/internal/api/handler/oscal/subject_integration_test.go
+++ b/internal/api/handler/oscal/subject_integration_test.go
@@ -42,7 +42,7 @@ func (suite *SubjectApiIntegrationSuite) SetupSuite() {
 	metrics := api.NewMetricsHandler(context.Background(), suite.logger)
 	suite.server = api.NewServer(context.Background(), suite.logger, suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(suite.server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(suite.server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 }
 
 func (suite *SubjectApiIntegrationSuite) SetupTest() {

--- a/internal/api/handler/oscal/system_security_plan_suggestions_integration_test.go
+++ b/internal/api/handler/oscal/system_security_plan_suggestions_integration_test.go
@@ -49,7 +49,7 @@ func (suite *SystemComponentSuggestionsIntegrationSuite) SetupSuite() {
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	suite.server = api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(suite.server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(suite.server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 }
 
 func (suite *SystemComponentSuggestionsIntegrationSuite) SetupTest() {

--- a/internal/api/handler/oscal/system_security_plans.go
+++ b/internal/api/handler/oscal/system_security_plans.go
@@ -28,6 +28,7 @@ type SystemSecurityPlanHandler struct {
 	db                *gorm.DB
 	profileCache      sync.Map // map[uuid.UUID][]string
 	suggestionService *relational.SystemComponentSuggestionService
+	riskService       *riskrel.RiskService
 }
 
 type SystemComponentRequest struct {
@@ -55,6 +56,7 @@ func NewSystemSecurityPlanHandler(sugar *zap.SugaredLogger, db *gorm.DB, evidenc
 		sugar:             sugar,
 		db:                db,
 		suggestionService: relational.NewSystemComponentSuggestionService(db, evidenceSvc),
+		riskService:       riskrel.NewRiskService(db),
 	}
 }
 
@@ -1941,6 +1943,19 @@ func (h *SystemSecurityPlanHandler) AttachProfile(ctx echo.Context) error {
 			}
 		}
 
+		// Build the new profile control set for orphan detection.
+		// We use an empty CatalogID here because controlIDs are plain control IDs
+		// without a catalog qualifier at this layer; RemediateOrphanedRisks
+		// normalises the comparison.
+		newProfileControlSet := make(map[riskrel.ControlKey]struct{}, len(controlIDs))
+		for _, cid := range controlIDs {
+			newProfileControlSet[riskrel.ControlKey{ControlID: cid}] = struct{}{}
+		}
+		if _, err := h.riskService.RemediateOrphanedRisks(tx, sspID, newProfileControlSet); err != nil {
+			h.sugar.Warnw("Failed to remediate orphaned risks on profile change", "sspId", sspID, "error", err)
+			return err
+		}
+
 		return nil
 	})
 
@@ -2041,7 +2056,22 @@ func (h *SystemSecurityPlanHandler) UpdateImportProfile(ctx echo.Context) error 
 	// Update the ImportProfile field in the SSP
 	ssp.ImportProfile = datatypes.NewJSONType(*relImportProfile)
 
-	if err := h.db.Save(&ssp).Error; err != nil {
+	// Wrap save and orphan cleanup in a single transaction so that a profile
+	// href update (which may effectively unbind the old profile) atomically
+	// remediates any risks that are no longer covered.
+	if err := h.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Save(&ssp).Error; err != nil {
+			return err
+		}
+		// UpdateImportProfile only changes the href metadata; it does not
+		// resolve a new control set, so we treat this as a full unbind and
+		// pass an empty control set to remediate all auto-generated risks.
+		if _, err := h.riskService.RemediateOrphanedRisks(tx, id, map[riskrel.ControlKey]struct{}{}); err != nil {
+			h.sugar.Warnw("Failed to remediate orphaned risks on import-profile update", "sspId", id, "error", err)
+			return err
+		}
+		return nil
+	}); err != nil {
 		h.sugar.Errorf("Failed to update import-profile: %v", err)
 		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
 	}

--- a/internal/api/handler/oscal/system_security_plans.go
+++ b/internal/api/handler/oscal/system_security_plans.go
@@ -1879,6 +1879,11 @@ func (h *SystemSecurityPlanHandler) AttachProfile(ctx echo.Context) error {
 		return ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("SSP not found")))
 	}
 
+	// Capture the old profile ID before the transaction mutates ssp.ProfileID via GORM Save.
+	// After tx.Save(&ssp) with ssp.Profile set, GORM updates ssp.ProfileID in memory to the
+	// new profile's ID, so we must snapshot the old value here.
+	oldProfileID := ssp.ProfileID
+
 	// Load the profile basic info
 	var profile relational.Profile
 	if err := h.db.First(&profile, "id = ?", profileID).Error; err != nil {
@@ -1957,9 +1962,9 @@ func (h *SystemSecurityPlanHandler) AttachProfile(ctx echo.Context) error {
 		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
 	}
 	// Enqueue orphaned risk cleanup after the transaction commits successfully.
-	// Passing old and new profile IDs so the worker can resolve the delta.
+	// oldProfileID was captured before the transaction so it reflects the pre-change binding.
 	if h.jobEnqueuer != nil {
-		if err := h.jobEnqueuer.EnqueueOrphanedRiskCleanup(ctx.Request().Context(), sspID, ssp.ProfileID, &profileID); err != nil {
+		if err := h.jobEnqueuer.EnqueueOrphanedRiskCleanup(ctx.Request().Context(), sspID, oldProfileID, &profileID); err != nil {
 			// Non-fatal: log and continue — the job can be retried or the next
 			// reconciliation pass will catch any orphans.
 			h.sugar.Warnw("Failed to enqueue orphaned risk cleanup job", "sspId", sspID, "error", err)
@@ -2058,23 +2063,13 @@ func (h *SystemSecurityPlanHandler) UpdateImportProfile(ctx echo.Context) error 
 	// Update the ImportProfile field in the SSP
 	ssp.ImportProfile = datatypes.NewJSONType(*relImportProfile)
 
-	// Save the updated SSP. Orphaned risk cleanup is handled asynchronously
-	// via a River job enqueued after the transaction commits.
+	// Save the updated SSP.
+	// UpdateImportProfile only updates the href metadata field (import-profile.href).
+	// It does NOT change ssp.ProfileID — the actual profile binding FK — so no controls
+	// are added or removed and no orphaned risk cleanup is required.
 	if err := h.db.Save(&ssp).Error; err != nil {
 		h.sugar.Errorf("Failed to update import-profile: %v", err)
 		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
-	}
-
-	// Enqueue orphaned risk cleanup after the save commits successfully.
-	// UpdateImportProfile only changes the href metadata and does not bind a new
-	// profile, so we pass nil for newProfileID — the worker will treat this as a
-	// full unbind and remediate all auto-generated risks.
-	if h.jobEnqueuer != nil {
-		if err := h.jobEnqueuer.EnqueueOrphanedRiskCleanup(ctx.Request().Context(), id, ssp.ProfileID, nil); err != nil {
-			// Non-fatal: log and continue — the job can be retried or the next
-			// reconciliation pass will catch any orphans.
-			h.sugar.Warnw("Failed to enqueue orphaned risk cleanup job on import-profile update", "sspId", id, "error", err)
-		}
 	}
 
 	return ctx.JSON(http.StatusOK, handler.GenericDataResponse[oscalTypes_1_1_3.ImportProfile]{Data: *relImportProfile.MarshalOscal()})

--- a/internal/api/handler/oscal/system_security_plans.go
+++ b/internal/api/handler/oscal/system_security_plans.go
@@ -1964,7 +1964,9 @@ func (h *SystemSecurityPlanHandler) AttachProfile(ctx echo.Context) error {
 	// Enqueue orphaned risk cleanup after the transaction commits successfully.
 	// oldProfileID was captured before the transaction so it reflects the pre-change binding.
 	if h.jobEnqueuer != nil {
-		if err := h.jobEnqueuer.EnqueueOrphanedRiskCleanup(ctx.Request().Context(), sspID, oldProfileID, &profileID); err != nil {
+		enqueueCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx.Request().Context()), 10*time.Second)
+		defer cancel()
+		if err := h.jobEnqueuer.EnqueueOrphanedRiskCleanup(enqueueCtx, sspID, oldProfileID, &profileID); err != nil {
 			// Non-fatal: log and continue — the job can be retried or the next
 			// reconciliation pass will catch any orphans.
 			h.sugar.Warnw("Failed to enqueue orphaned risk cleanup job", "sspId", sspID, "error", err)

--- a/internal/api/handler/oscal/system_security_plans.go
+++ b/internal/api/handler/oscal/system_security_plans.go
@@ -1,6 +1,7 @@
 package oscal
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -23,12 +24,18 @@ import (
 	"gorm.io/gorm"
 )
 
+// SSPJobEnqueuer is a minimal interface for enqueueing SSP-related background jobs.
+// Defined here to avoid a circular import between the oscal handler and worker packages.
+type SSPJobEnqueuer interface {
+	EnqueueOrphanedRiskCleanup(ctx context.Context, sspID uuid.UUID, oldProfileID, newProfileID *uuid.UUID) error
+}
+
 type SystemSecurityPlanHandler struct {
 	sugar             *zap.SugaredLogger
 	db                *gorm.DB
 	profileCache      sync.Map // map[uuid.UUID][]string
 	suggestionService *relational.SystemComponentSuggestionService
-	riskService       *riskrel.RiskService
+	jobEnqueuer       SSPJobEnqueuer
 }
 
 type SystemComponentRequest struct {
@@ -51,12 +58,12 @@ func (r *ApplySuggestionRequest) Validate() error {
 	return nil
 }
 
-func NewSystemSecurityPlanHandler(sugar *zap.SugaredLogger, db *gorm.DB, evidenceSvc *evidencesvc.EvidenceService) *SystemSecurityPlanHandler {
+func NewSystemSecurityPlanHandler(sugar *zap.SugaredLogger, db *gorm.DB, evidenceSvc *evidencesvc.EvidenceService, jobEnqueuer SSPJobEnqueuer) *SystemSecurityPlanHandler {
 	return &SystemSecurityPlanHandler{
 		sugar:             sugar,
 		db:                db,
 		suggestionService: relational.NewSystemComponentSuggestionService(db, evidenceSvc),
-		riskService:       riskrel.NewRiskService(db),
+		jobEnqueuer:       jobEnqueuer,
 	}
 }
 
@@ -1943,25 +1950,20 @@ func (h *SystemSecurityPlanHandler) AttachProfile(ctx echo.Context) error {
 			}
 		}
 
-		// Build the new profile control set for orphan detection.
-		// We use an empty CatalogID here because controlIDs are plain control IDs
-		// without a catalog qualifier at this layer; RemediateOrphanedRisks
-		// normalises the comparison.
-		newProfileControlSet := make(map[riskrel.ControlKey]struct{}, len(controlIDs))
-		for _, cid := range controlIDs {
-			newProfileControlSet[riskrel.ControlKey{ControlID: cid}] = struct{}{}
-		}
-		if _, err := h.riskService.RemediateOrphanedRisks(tx, sspID, newProfileControlSet); err != nil {
-			h.sugar.Warnw("Failed to remediate orphaned risks on profile change", "sspId", sspID, "error", err)
-			return err
-		}
-
 		return nil
 	})
-
 	if err != nil {
 		h.sugar.Errorf("Failed to attach profile to SSP: %v", err)
 		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+	// Enqueue orphaned risk cleanup after the transaction commits successfully.
+	// Passing old and new profile IDs so the worker can resolve the delta.
+	if h.jobEnqueuer != nil {
+		if err := h.jobEnqueuer.EnqueueOrphanedRiskCleanup(ctx.Request().Context(), sspID, ssp.ProfileID, &profileID); err != nil {
+			// Non-fatal: log and continue — the job can be retried or the next
+			// reconciliation pass will catch any orphans.
+			h.sugar.Warnw("Failed to enqueue orphaned risk cleanup job", "sspId", sspID, "error", err)
+		}
 	}
 
 	// Reload SSP to ensure the memory state matches the database (including newly created requirements)
@@ -2056,24 +2058,23 @@ func (h *SystemSecurityPlanHandler) UpdateImportProfile(ctx echo.Context) error 
 	// Update the ImportProfile field in the SSP
 	ssp.ImportProfile = datatypes.NewJSONType(*relImportProfile)
 
-	// Wrap save and orphan cleanup in a single transaction so that a profile
-	// href update (which may effectively unbind the old profile) atomically
-	// remediates any risks that are no longer covered.
-	if err := h.db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Save(&ssp).Error; err != nil {
-			return err
-		}
-		// UpdateImportProfile only changes the href metadata; it does not
-		// resolve a new control set, so we treat this as a full unbind and
-		// pass an empty control set to remediate all auto-generated risks.
-		if _, err := h.riskService.RemediateOrphanedRisks(tx, id, map[riskrel.ControlKey]struct{}{}); err != nil {
-			h.sugar.Warnw("Failed to remediate orphaned risks on import-profile update", "sspId", id, "error", err)
-			return err
-		}
-		return nil
-	}); err != nil {
+	// Save the updated SSP. Orphaned risk cleanup is handled asynchronously
+	// via a River job enqueued after the transaction commits.
+	if err := h.db.Save(&ssp).Error; err != nil {
 		h.sugar.Errorf("Failed to update import-profile: %v", err)
 		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	// Enqueue orphaned risk cleanup after the save commits successfully.
+	// UpdateImportProfile only changes the href metadata and does not bind a new
+	// profile, so we pass nil for newProfileID — the worker will treat this as a
+	// full unbind and remediate all auto-generated risks.
+	if h.jobEnqueuer != nil {
+		if err := h.jobEnqueuer.EnqueueOrphanedRiskCleanup(ctx.Request().Context(), id, ssp.ProfileID, nil); err != nil {
+			// Non-fatal: log and continue — the job can be retried or the next
+			// reconciliation pass will catch any orphans.
+			h.sugar.Warnw("Failed to enqueue orphaned risk cleanup job on import-profile update", "sspId", id, "error", err)
+		}
 	}
 
 	return ctx.JSON(http.StatusOK, handler.GenericDataResponse[oscalTypes_1_1_3.ImportProfile]{Data: *relImportProfile.MarshalOscal()})

--- a/internal/api/handler/oscal/system_security_plans_test.go
+++ b/internal/api/handler/oscal/system_security_plans_test.go
@@ -157,7 +157,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateSSP() {
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	ssp := suite.createBasicSSP()
 
@@ -189,7 +189,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateSSPValidationError
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	testCases := []struct {
 		name        string
@@ -258,7 +258,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestGetSSP() {
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first
 	ssp := suite.createBasicSSP()
@@ -295,7 +295,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestGetSSPNotFound() {
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	nonExistentUUID := uuid.New().String()
 	req := suite.createRequest("GET", fmt.Sprintf("/api/oscal/system-security-plans/%s", nonExistentUUID), nil)
@@ -318,7 +318,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestListSSPs() {
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create multiple SSPs
 	ssp1 := suite.createBasicSSP()
@@ -382,7 +382,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateImplementedRequire
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first (without statements)
 	ssp := suite.createBasicSSP()
@@ -500,7 +500,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateImplementedRequire
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first
 	ssp := suite.createBasicSSP()
@@ -577,7 +577,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestUpdateImplementedRequire
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first (without statements)
 	ssp := suite.createBasicSSP()
@@ -683,7 +683,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestUpdateImplementedRequire
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	ssp := suite.createBasicSSP()
 	componentUuid := ssp.SystemImplementation.Components[0].UUID
@@ -787,7 +787,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestUpdateImplementedRequire
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first (without statements)
 	ssp := suite.createBasicSSP()
@@ -908,7 +908,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestDeleteImplementedRequire
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first (without statements)
 	ssp := suite.createBasicSSP()
@@ -989,7 +989,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateImplementedRequire
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first (without statements)
 	ssp := suite.createBasicSSP()
@@ -1098,7 +1098,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestUpdateImplementedRequire
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first
 	ssp := suite.createBasicSSP()
@@ -1180,7 +1180,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestSystemImplementationCRUD
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first
 	ssp := suite.createBasicSSP()
@@ -1338,7 +1338,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestSystemImplementationUser
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first
 	ssp := suite.createBasicSSP()
@@ -1478,7 +1478,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestSystemImplementationComp
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first
 	ssp := suite.createBasicSSP()
@@ -1684,7 +1684,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestSystemImplementationInve
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first
 	ssp := suite.createBasicSSP()
@@ -1870,7 +1870,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestSystemImplementationLeve
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP first
 	ssp := suite.createBasicSSP()
@@ -2018,7 +2018,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateNetworkArchitectur
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP with a NetworkArchitecture present
 	ssp := suite.createBasicSSP()
@@ -2090,7 +2090,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateDataFlowDiagram() 
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP with a DataFlow present
 	ssp := suite.createBasicSSP()
@@ -2161,7 +2161,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateAuthorizationBound
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP with an AuthorizationBoundary present
 	ssp := suite.createBasicSSP()
@@ -2232,7 +2232,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateNetworkArchitectur
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// 1) Invalid SSP ID in path
 	badDiagram := oscalTypes_1_1_3.Diagram{UUID: uuid.New().String(), Description: "bad"}
@@ -2298,7 +2298,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateDataFlowDiagram_Ne
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// 1) Invalid SSP ID in path
 	badDiagram := oscalTypes_1_1_3.Diagram{UUID: uuid.New().String(), Description: "bad"}
@@ -2363,7 +2363,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateAuthorizationBound
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// 1) Invalid SSP ID in path
 	badDiagram := oscalTypes_1_1_3.Diagram{UUID: uuid.New().String(), Description: "bad"}
@@ -2410,7 +2410,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestDeleteNetworkArchitectur
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP with NA and one diagram
 	ssp := suite.createBasicSSP()
@@ -2460,7 +2460,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestDeleteDataFlowDiagram() 
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP with DF and one diagram
 	ssp := suite.createBasicSSP()
@@ -2510,7 +2510,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestDeleteAuthorizationBound
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// Create SSP with AB and one diagram
 	ssp := suite.createBasicSSP()
@@ -2561,7 +2561,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestDeleteNetworkArchitectur
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// invalid SSP id
 	req := suite.createRequest(http.MethodDelete, "/api/oscal/system-security-plans/not-a-uuid/system-characteristics/network-architecture/diagrams/not-a-uuid", nil)
@@ -2601,7 +2601,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestDeleteDataFlowDiagram_Ne
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// invalid SSP id
 	req := suite.createRequest(http.MethodDelete, "/api/oscal/system-security-plans/not-a-uuid/system-characteristics/data-flow/diagrams/not-a-uuid", nil)
@@ -2641,7 +2641,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestDeleteAuthorizationBound
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// invalid SSP id
 	req := suite.createRequest(http.MethodDelete, "/api/oscal/system-security-plans/not-a-uuid/system-characteristics/authorization-boundary/diagrams/not-a-uuid", nil)
@@ -2681,7 +2681,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestAttachProfile() {
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// 1. Setup data: Catalog -> Controls -> Profile
 	catalog := &relational.Catalog{
@@ -2766,7 +2766,7 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestGetImplementedRequiremen
 	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
 	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
-	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil)
 
 	// 1. Setup data: Catalog -> Controls -> Two Profiles
 	catalog := &relational.Catalog{

--- a/internal/api/handler/oscal/task_integration_test.go
+++ b/internal/api/handler/oscal/task_integration_test.go
@@ -42,7 +42,7 @@ func (suite *TaskApiIntegrationSuite) SetupSuite() {
 	metrics := api.NewMetricsHandler(context.Background(), suite.logger)
 	suite.server = api.NewServer(context.Background(), suite.logger, suite.Config, metrics)
 	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, suite.logger, suite.Config, nil)
-	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc)
+	RegisterHandlers(suite.server, suite.logger, suite.DB, suite.Config, evidenceSvc, nil)
 }
 
 func (suite *TaskApiIntegrationSuite) SetupTest() {

--- a/internal/service/relational/risks/remediate_orphaned_risks_test.go
+++ b/internal/service/relational/risks/remediate_orphaned_risks_test.go
@@ -204,6 +204,42 @@ func TestRemediateOrphanedRisks_SkipsManualRisksWithTemplate(t *testing.T) {
 	assert.Equal(t, string(RiskStatusOpen), updated.Status)
 }
 
+func TestRemediateOrphanedRisks_RemediatesOscalImportWithoutTemplate(t *testing.T) {
+	db := newRiskServiceTestDB(t)
+	svc := NewRiskService(db)
+
+	sspID := uuid.New()
+	catalogID := uuid.New()
+	likelihood := "moderate"
+	impact := "moderate"
+
+	risk, err := svc.Create(CreateRiskParams{
+		Risk: Risk{
+			Title:       "OSCAL imported risk",
+			Description: "imported",
+			Likelihood:  &likelihood,
+			Impact:      &impact,
+			Status:      string(RiskStatusOpen),
+			SSPID:       sspID,
+			SourceType:  string(RiskSourceTypeOscalImport),
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&RiskControlLink{
+		RiskID:    *risk.ID,
+		CatalogID: catalogID,
+		ControlID: "AC-1",
+	}).Error)
+
+	n, err := svc.RemediateOrphanedRisks(db, sspID, map[ControlKey]struct{}{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "OSCAL-imported risks should be remediated even without a template")
+
+	var updated Risk
+	require.NoError(t, db.First(&updated, "id = ?", risk.ID).Error)
+	assert.Equal(t, string(RiskStatusRemediated), updated.Status)
+}
+
 // TestRemediateOrphanedRisks_SkipsTerminalRisks verifies that risks already in
 // a terminal state (remediated, closed) are not touched.
 func TestRemediateOrphanedRisks_SkipsTerminalRisks(t *testing.T) {

--- a/internal/service/relational/risks/remediate_orphaned_risks_test.go
+++ b/internal/service/relational/risks/remediate_orphaned_risks_test.go
@@ -145,6 +145,73 @@ func TestRemediateOrphanedRisks_FullUnbind(t *testing.T) {
 	}
 }
 
+func TestRemediateOrphanedRisks_FullUnbindRemediatesAutoRiskWithoutControlLinks(t *testing.T) {
+	db := newRiskServiceTestDB(t)
+	svc := NewRiskService(db)
+
+	sspID := uuid.New()
+	templateID := uuid.New()
+	likelihood := "moderate"
+	impact := "moderate"
+
+	risk, err := svc.Create(CreateRiskParams{
+		Risk: Risk{
+			Title:          "Auto-generated risk without controls",
+			Description:    "auto-generated",
+			Likelihood:     &likelihood,
+			Impact:         &impact,
+			Status:         string(RiskStatusOpen),
+			SSPID:          sspID,
+			RiskTemplateID: &templateID,
+			SourceType:     string(RiskSourceTypeEvidenceAuto),
+		},
+	})
+	require.NoError(t, err)
+
+	n, err := svc.RemediateOrphanedRisks(db, sspID, map[ControlKey]struct{}{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "auto-generated risks without control links should be remediated on full unbind")
+
+	var updated Risk
+	require.NoError(t, db.First(&updated, "id = ?", risk.ID).Error)
+	assert.Equal(t, string(RiskStatusRemediated), updated.Status)
+}
+
+func TestRemediateOrphanedRisks_PartialChangeSkipsAutoRiskWithoutControlLinks(t *testing.T) {
+	db := newRiskServiceTestDB(t)
+	svc := NewRiskService(db)
+
+	sspID := uuid.New()
+	templateID := uuid.New()
+	likelihood := "moderate"
+	impact := "moderate"
+
+	risk, err := svc.Create(CreateRiskParams{
+		Risk: Risk{
+			Title:          "Auto-generated risk without controls",
+			Description:    "auto-generated",
+			Likelihood:     &likelihood,
+			Impact:         &impact,
+			Status:         string(RiskStatusOpen),
+			SSPID:          sspID,
+			RiskTemplateID: &templateID,
+			SourceType:     string(RiskSourceTypeEvidenceAuto),
+		},
+	})
+	require.NoError(t, err)
+
+	profileSet := map[ControlKey]struct{}{
+		{ControlID: "AC-1"}: {},
+	}
+	n, err := svc.RemediateOrphanedRisks(db, sspID, profileSet)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "auto-generated risks without control links should be skipped on partial profile changes")
+
+	var updated Risk
+	require.NoError(t, db.First(&updated, "id = ?", risk.ID).Error)
+	assert.Equal(t, string(RiskStatusOpen), updated.Status)
+}
+
 // TestRemediateOrphanedRisks_SkipsManualRisks verifies that manually created
 // risks (no RiskTemplateID) are never remediated even if their control is removed.
 func TestRemediateOrphanedRisks_SkipsManualRisks(t *testing.T) {

--- a/internal/service/relational/risks/remediate_orphaned_risks_test.go
+++ b/internal/service/relational/risks/remediate_orphaned_risks_test.go
@@ -1,0 +1,268 @@
+package risks
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createAutoRisk creates a risk linked to a template (auto-generated) with the
+// given status and control link. Returns the created risk.
+func createAutoRisk(t *testing.T, svc *RiskService, sspID uuid.UUID, status RiskStatus, controlID string, catalogID uuid.UUID) *Risk {
+	t.Helper()
+	templateID := uuid.New()
+	likelihood := "moderate"
+	impact := "moderate"
+	r, err := svc.Create(CreateRiskParams{
+		Risk: Risk{
+			Title:          "Test risk " + controlID,
+			Description:    "auto-generated",
+			Likelihood:     &likelihood,
+			Impact:         &impact,
+			Status:         string(status),
+			SSPID:          sspID,
+			RiskTemplateID: &templateID,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, r)
+
+	link := &RiskControlLink{
+		RiskID:    *r.ID,
+		CatalogID: catalogID,
+		ControlID: controlID,
+	}
+	require.NoError(t, svc.db.Create(link).Error)
+	return r
+}
+
+// createManualRisk creates a risk with no template (manually created).
+func createManualRisk(t *testing.T, svc *RiskService, sspID uuid.UUID, status RiskStatus, controlID string, catalogID uuid.UUID) *Risk {
+	t.Helper()
+	likelihood := "low"
+	impact := "low"
+	r, err := svc.Create(CreateRiskParams{
+		Risk: Risk{
+			Title:       "Manual risk " + controlID,
+			Description: "manual",
+			Likelihood:  &likelihood,
+			Impact:      &impact,
+			Status:      string(status),
+			SSPID:       sspID,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, r)
+
+	if controlID != "" {
+		link := &RiskControlLink{
+			RiskID:    *r.ID,
+			CatalogID: catalogID,
+			ControlID: controlID,
+		}
+		require.NoError(t, svc.db.Create(link).Error)
+	}
+	return r
+}
+
+// TestRemediateOrphanedRisks_NoOp verifies that when all risk controls are
+// still present in the new profile set, no risks are remediated.
+func TestRemediateOrphanedRisks_NoOp(t *testing.T) {
+	db := newRiskServiceTestDB(t)
+	svc := NewRiskService(db)
+
+	sspID := uuid.New()
+	catalogID := uuid.New()
+
+	risk := createAutoRisk(t, svc, sspID, RiskStatusOpen, "AC-1", catalogID)
+
+	profileSet := map[ControlKey]struct{}{
+		{ControlID: "AC-1"}: {},
+	}
+
+	n, err := svc.RemediateOrphanedRisks(db, sspID, profileSet)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "no risks should be remediated when controls are still present")
+
+	var updated Risk
+	require.NoError(t, db.First(&updated, "id = ?", risk.ID).Error)
+	assert.Equal(t, string(RiskStatusOpen), updated.Status, "risk status should remain open")
+}
+
+// TestRemediateOrphanedRisks_PartialRemediation verifies that only risks whose
+// controls are absent from the new profile set are remediated.
+func TestRemediateOrphanedRisks_PartialRemediation(t *testing.T) {
+	db := newRiskServiceTestDB(t)
+	svc := NewRiskService(db)
+
+	sspID := uuid.New()
+	catalogID := uuid.New()
+
+	kept := createAutoRisk(t, svc, sspID, RiskStatusOpen, "AC-1", catalogID)
+	orphaned := createAutoRisk(t, svc, sspID, RiskStatusOpen, "AC-2", catalogID)
+
+	// New profile only has AC-1; AC-2 is removed.
+	profileSet := map[ControlKey]struct{}{
+		{ControlID: "AC-1"}: {},
+	}
+
+	n, err := svc.RemediateOrphanedRisks(db, sspID, profileSet)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "exactly one risk should be remediated")
+
+	var keptRisk Risk
+	require.NoError(t, db.First(&keptRisk, "id = ?", kept.ID).Error)
+	assert.Equal(t, string(RiskStatusOpen), keptRisk.Status, "AC-1 risk should remain open")
+
+	var orphanedRisk Risk
+	require.NoError(t, db.First(&orphanedRisk, "id = ?", orphaned.ID).Error)
+	assert.Equal(t, string(RiskStatusRemediated), orphanedRisk.Status, "AC-2 risk should be remediated")
+}
+
+// TestRemediateOrphanedRisks_FullUnbind verifies that when an empty profile
+// set is passed (profile unbound), all auto-generated open risks are remediated.
+func TestRemediateOrphanedRisks_FullUnbind(t *testing.T) {
+	db := newRiskServiceTestDB(t)
+	svc := NewRiskService(db)
+
+	sspID := uuid.New()
+	catalogID := uuid.New()
+
+	r1 := createAutoRisk(t, svc, sspID, RiskStatusOpen, "AC-1", catalogID)
+	r2 := createAutoRisk(t, svc, sspID, RiskStatusOpen, "AC-2", catalogID)
+
+	n, err := svc.RemediateOrphanedRisks(db, sspID, map[ControlKey]struct{}{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "both risks should be remediated on full unbind")
+
+	for _, id := range []*uuid.UUID{r1.ID, r2.ID} {
+		var r Risk
+		require.NoError(t, db.First(&r, "id = ?", id).Error)
+		assert.Equal(t, string(RiskStatusRemediated), r.Status)
+	}
+}
+
+// TestRemediateOrphanedRisks_SkipsManualRisks verifies that manually created
+// risks (no RiskTemplateID) are never remediated even if their control is removed.
+func TestRemediateOrphanedRisks_SkipsManualRisks(t *testing.T) {
+	db := newRiskServiceTestDB(t)
+	svc := NewRiskService(db)
+
+	sspID := uuid.New()
+	catalogID := uuid.New()
+
+	manual := createManualRisk(t, svc, sspID, RiskStatusOpen, "AC-1", catalogID)
+
+	// Profile set is empty — would remediate auto risks, but not manual ones.
+	n, err := svc.RemediateOrphanedRisks(db, sspID, map[ControlKey]struct{}{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "manual risks must not be remediated")
+
+	var r Risk
+	require.NoError(t, db.First(&r, "id = ?", manual.ID).Error)
+	assert.Equal(t, string(RiskStatusOpen), r.Status)
+}
+
+// TestRemediateOrphanedRisks_SkipsTerminalRisks verifies that risks already in
+// a terminal state (remediated, closed) are not touched.
+func TestRemediateOrphanedRisks_SkipsTerminalRisks(t *testing.T) {
+	db := newRiskServiceTestDB(t)
+	svc := NewRiskService(db)
+
+	sspID := uuid.New()
+	catalogID := uuid.New()
+
+	alreadyRemediated := createAutoRisk(t, svc, sspID, RiskStatusRemediated, "AC-1", catalogID)
+	alreadyClosed := createAutoRisk(t, svc, sspID, RiskStatusClosed, "AC-2", catalogID)
+
+	n, err := svc.RemediateOrphanedRisks(db, sspID, map[ControlKey]struct{}{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "terminal risks must not be re-remediated")
+
+	for _, id := range []*uuid.UUID{alreadyRemediated.ID, alreadyClosed.ID} {
+		var r Risk
+		require.NoError(t, db.First(&r, "id = ?", id).Error)
+		// Status should be unchanged.
+		assert.NotEqual(t, string(RiskStatusOpen), r.Status)
+	}
+}
+
+// TestRemediateOrphanedRisks_EmitsStatusChangeEvent verifies that a
+// status_changed RiskEvent is emitted for each remediated risk.
+func TestRemediateOrphanedRisks_EmitsStatusChangeEvent(t *testing.T) {
+	db := newRiskServiceTestDB(t)
+	svc := NewRiskService(db)
+
+	sspID := uuid.New()
+	catalogID := uuid.New()
+
+	risk := createAutoRisk(t, svc, sspID, RiskStatusOpen, "AC-1", catalogID)
+
+	n, err := svc.RemediateOrphanedRisks(db, sspID, map[ControlKey]struct{}{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	var events []RiskEvent
+	require.NoError(t, db.
+		Where("risk_id = ? AND event_type = ?", risk.ID, string(RiskEventTypeStatusChange)).
+		Find(&events).Error)
+	assert.Len(t, events, 1, "one status_changed event should be emitted")
+	assert.Equal(t, string(RiskEventTypeStatusChange), events[0].EventType)
+}
+
+// TestRemediateOrphanedRisks_CatalogIDFallback verifies that a risk linked with
+// a full CatalogID+ControlID key is still matched when the profile set only
+// provides a bare ControlID (no CatalogID).
+func TestRemediateOrphanedRisks_CatalogIDFallback(t *testing.T) {
+	db := newRiskServiceTestDB(t)
+	svc := NewRiskService(db)
+
+	sspID := uuid.New()
+	catalogID := uuid.New()
+
+	// Risk is linked with a full catalog+control key.
+	kept := createAutoRisk(t, svc, sspID, RiskStatusOpen, "AC-1", catalogID)
+
+	// Profile set only has a bare control ID (no CatalogID) — as produced by
+	// the profile resolution layer in AttachProfile.
+	profileSet := map[ControlKey]struct{}{
+		{CatalogID: "", ControlID: "AC-1"}: {},
+	}
+
+	n, err := svc.RemediateOrphanedRisks(db, sspID, profileSet)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "risk should not be orphaned when matched by bare ControlID")
+
+	var r Risk
+	require.NoError(t, db.First(&r, "id = ?", kept.ID).Error)
+	assert.Equal(t, string(RiskStatusOpen), r.Status)
+}
+
+// TestRemediateOrphanedRisks_IsolatedBySSP verifies that risks belonging to a
+// different SSP are not affected.
+func TestRemediateOrphanedRisks_IsolatedBySSP(t *testing.T) {
+	db := newRiskServiceTestDB(t)
+	svc := NewRiskService(db)
+
+	sspA := uuid.New()
+	sspB := uuid.New()
+	catalogID := uuid.New()
+
+	riskA := createAutoRisk(t, svc, sspA, RiskStatusOpen, "AC-1", catalogID)
+	riskB := createAutoRisk(t, svc, sspB, RiskStatusOpen, "AC-1", catalogID)
+
+	// Unbind sspA entirely.
+	n, err := svc.RemediateOrphanedRisks(db, sspA, map[ControlKey]struct{}{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "only sspA risk should be remediated")
+
+	var rA Risk
+	require.NoError(t, db.First(&rA, "id = ?", riskA.ID).Error)
+	assert.Equal(t, string(RiskStatusRemediated), rA.Status, "sspA risk should be remediated")
+
+	var rB Risk
+	require.NoError(t, db.First(&rB, "id = ?", riskB.ID).Error)
+	assert.Equal(t, string(RiskStatusOpen), rB.Status, "sspB risk must not be touched")
+}

--- a/internal/service/relational/risks/remediate_orphaned_risks_test.go
+++ b/internal/service/relational/risks/remediate_orphaned_risks_test.go
@@ -24,6 +24,7 @@ func createAutoRisk(t *testing.T, svc *RiskService, sspID uuid.UUID, status Risk
 			Status:         string(status),
 			SSPID:          sspID,
 			RiskTemplateID: &templateID,
+			SourceType:     string(RiskSourceTypeEvidenceAuto),
 		},
 	})
 	require.NoError(t, err)
@@ -165,6 +166,44 @@ func TestRemediateOrphanedRisks_SkipsManualRisks(t *testing.T) {
 	assert.Equal(t, string(RiskStatusOpen), r.Status)
 }
 
+func TestRemediateOrphanedRisks_SkipsManualRisksWithTemplate(t *testing.T) {
+	db := newRiskServiceTestDB(t)
+	svc := NewRiskService(db)
+
+	sspID := uuid.New()
+	catalogID := uuid.New()
+	templateID := uuid.New()
+	likelihood := "low"
+	impact := "low"
+
+	risk, err := svc.Create(CreateRiskParams{
+		Risk: Risk{
+			Title:          "Manual template-backed risk",
+			Description:    "manual",
+			Likelihood:     &likelihood,
+			Impact:         &impact,
+			Status:         string(RiskStatusOpen),
+			SSPID:          sspID,
+			RiskTemplateID: &templateID,
+			SourceType:     string(RiskSourceTypeManual),
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&RiskControlLink{
+		RiskID:    *risk.ID,
+		CatalogID: catalogID,
+		ControlID: "AC-1",
+	}).Error)
+
+	n, err := svc.RemediateOrphanedRisks(db, sspID, map[ControlKey]struct{}{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "manual risks must not be remediated even when template-backed")
+
+	var updated Risk
+	require.NoError(t, db.First(&updated, "id = ?", risk.ID).Error)
+	assert.Equal(t, string(RiskStatusOpen), updated.Status)
+}
+
 // TestRemediateOrphanedRisks_SkipsTerminalRisks verifies that risks already in
 // a terminal state (remediated, closed) are not touched.
 func TestRemediateOrphanedRisks_SkipsTerminalRisks(t *testing.T) {
@@ -210,6 +249,8 @@ func TestRemediateOrphanedRisks_EmitsStatusChangeEvent(t *testing.T) {
 		Find(&events).Error)
 	assert.Len(t, events, 1, "one status_changed event should be emitted")
 	assert.Equal(t, string(RiskEventTypeStatusChange), events[0].EventType)
+	assert.NotEmpty(t, events[0].RiskSnapshot, "status_changed event should include the standard risk snapshot")
+	assert.Equal(t, string(RiskStatusRemediated), events[0].RiskSnapshot["status"])
 }
 
 // TestRemediateOrphanedRisks_CatalogIDFallback verifies that a risk linked with

--- a/internal/service/relational/risks/service.go
+++ b/internal/service/relational/risks/service.go
@@ -1387,7 +1387,7 @@ func (s *RiskService) RemediateOrphanedRisks(
 	var candidates []Risk
 	if err := tx.
 		Where(
-			"ssp_id = ? AND risk_template_id IS NOT NULL AND source_type IN ? AND status NOT IN ?",
+			"ssp_id = ? AND source_type IN ? AND status NOT IN ?",
 			sspID,
 			[]string{string(RiskSourceTypeEvidenceAuto), string(RiskSourceTypeOscalImport)},
 			[]string{string(RiskStatusClosed), string(RiskStatusRemediated)},

--- a/internal/service/relational/risks/service.go
+++ b/internal/service/relational/risks/service.go
@@ -1361,3 +1361,128 @@ func rollbackTxOnPanic(tx *gorm.DB) {
 		panic(r)
 	}
 }
+
+// ControlKey is a composite key used to match a risk's linked controls against
+// a profile's control set. CatalogID may be empty when only control IDs are
+// available (e.g. from the profile resolution layer).
+type ControlKey struct {
+	CatalogID string
+	ControlID string
+}
+
+// RemediateOrphanedRisks transitions all open, auto-generated risks for the
+// given SSP to remediated when none of their linked controls exist in
+// newProfileControlSet. It must be called inside the caller transaction (tx)
+// so that the profile update and the risk cleanup are atomic.
+//
+// Pass an empty newProfileControlSet when the profile has been unbound entirely
+// (all auto-generated risks become orphaned by definition).
+//
+// Returns the number of risks that were remediated.
+func (s *RiskService) RemediateOrphanedRisks(
+	tx *gorm.DB,
+	sspID uuid.UUID,
+	newProfileControlSet map[ControlKey]struct{},
+) (int, error) {
+	var candidates []Risk
+	if err := tx.
+		Where(
+			"ssp_id = ? AND risk_template_id IS NOT NULL AND status NOT IN ?",
+			sspID,
+			[]string{string(RiskStatusClosed), string(RiskStatusRemediated)},
+		).
+		Find(&candidates).Error; err != nil {
+		return 0, fmt.Errorf("remediate orphaned risks: load candidates failed: %w", err)
+	}
+	if len(candidates) == 0 {
+		return 0, nil
+	}
+
+	riskIDs := make([]uuid.UUID, 0, len(candidates))
+	for _, r := range candidates {
+		if r.ID != nil {
+			riskIDs = append(riskIDs, *r.ID)
+		}
+	}
+
+	var links []RiskControlLink
+	if err := tx.Where("risk_id IN ?", riskIDs).Find(&links).Error; err != nil {
+		return 0, fmt.Errorf("remediate orphaned risks: load control links failed: %w", err)
+	}
+
+	riskControls := make(map[uuid.UUID][]ControlKey, len(candidates))
+	for _, l := range links {
+		riskControls[l.RiskID] = append(riskControls[l.RiskID], ControlKey{
+			CatalogID: l.CatalogID.String(),
+			ControlID: strings.ToUpper(l.ControlID),
+		})
+	}
+
+	normalisedProfileSet := make(map[ControlKey]struct{}, len(newProfileControlSet))
+	for k := range newProfileControlSet {
+		normalisedProfileSet[ControlKey{
+			CatalogID: k.CatalogID,
+			ControlID: strings.ToUpper(k.ControlID),
+		}] = struct{}{}
+	}
+
+	remediated := 0
+	occurredAt := time.Now().UTC()
+
+	for i := range candidates {
+		risk := &candidates[i]
+		if risk.ID == nil {
+			continue
+		}
+
+		riskControlKeys := riskControls[*risk.ID]
+		if len(riskControlKeys) == 0 {
+			continue
+		}
+
+		if len(normalisedProfileSet) > 0 {
+			orphaned := true
+			for _, ck := range riskControlKeys {
+				// Match on ControlID alone when the stored link has a CatalogID
+				// but the profile set was built without one (or vice versa).
+				if _, exists := normalisedProfileSet[ck]; exists {
+					orphaned = false
+					break
+				}
+				if _, exists := normalisedProfileSet[ControlKey{ControlID: ck.ControlID}]; exists {
+					orphaned = false
+					break
+				}
+			}
+			if !orphaned {
+				continue
+			}
+		}
+
+		oldStatus := risk.Status
+		if err := tx.Model(risk).Update("status", string(RiskStatusRemediated)).Error; err != nil {
+			return remediated, fmt.Errorf("remediate orphaned risks: update status failed for risk %s: %w", *risk.ID, err)
+		}
+
+		payload := datatypes.JSONMap{
+			"from":   oldStatus,
+			"to":     string(RiskStatusRemediated),
+			"reason": "orphaned_profile_change",
+		}
+		details := BuildRiskEventDetails(string(RiskEventTypeStatusChange), payload, occurredAt)
+		event := &RiskEvent{
+			RiskID:     *risk.ID,
+			EventType:  string(RiskEventTypeStatusChange),
+			OccurredAt: occurredAt,
+			Details:    &details,
+			Payload:    payload,
+		}
+		if err := tx.Create(event).Error; err != nil {
+			return remediated, fmt.Errorf("remediate orphaned risks: emit event failed for risk %s: %w", *risk.ID, err)
+		}
+
+		remediated++
+	}
+
+	return remediated, nil
+}

--- a/internal/service/relational/risks/service.go
+++ b/internal/service/relational/risks/service.go
@@ -1427,6 +1427,12 @@ func (s *RiskService) RemediateOrphanedRisks(
 		}] = struct{}{}
 	}
 
+	type remediationEvent struct {
+		riskID  uuid.UUID
+		payload datatypes.JSONMap
+	}
+	events := make([]remediationEvent, 0, len(candidates))
+
 	remediated := 0
 	for i := range candidates {
 		risk := &candidates[i]
@@ -1468,11 +1474,56 @@ func (s *RiskService) RemediateOrphanedRisks(
 			"to":     string(RiskStatusRemediated),
 			"reason": "orphaned_profile_change",
 		}
-		if err := s.logRiskEvent(tx, *risk.ID, RiskEventTypeStatusChange, nil, payload); err != nil {
-			return remediated, fmt.Errorf("remediate orphaned risks: emit event failed for risk %s: %w", *risk.ID, err)
+		events = append(events, remediationEvent{riskID: *risk.ID, payload: payload})
+		remediated++
+	}
+	if len(events) == 0 {
+		return 0, nil
+	}
+
+	remediatedIDs := make([]uuid.UUID, 0, len(events))
+	for _, event := range events {
+		remediatedIDs = append(remediatedIDs, event.riskID)
+	}
+
+	var snapshotRisks []Risk
+	if err := tx.
+		Preload("OwnerAssignments").
+		Preload("ThreatRefs", func(db *gorm.DB) *gorm.DB { return db.Order("system ASC, external_id ASC") }).
+		Preload("Remediation").
+		Preload("Remediation.Tasks", func(db *gorm.DB) *gorm.DB { return db.Order("order_index ASC") }).
+		Where("id IN ?", remediatedIDs).
+		Find(&snapshotRisks).Error; err != nil {
+		return remediated, fmt.Errorf("remediate orphaned risks: load snapshots failed: %w", err)
+	}
+
+	snapshots := make(map[uuid.UUID]datatypes.JSONMap, len(snapshotRisks))
+	for i := range snapshotRisks {
+		risk := &snapshotRisks[i]
+		if risk.ID == nil {
+			continue
 		}
 
-		remediated++
+		raw, err := json.Marshal(risk)
+		if err != nil {
+			return remediated, fmt.Errorf("remediate orphaned risks: marshal snapshot failed for risk %s: %w", *risk.ID, err)
+		}
+
+		snapshot := datatypes.JSONMap{}
+		if err := json.Unmarshal(raw, &snapshot); err != nil {
+			return remediated, fmt.Errorf("remediate orphaned risks: unmarshal snapshot failed for risk %s: %w", *risk.ID, err)
+		}
+		snapshots[*risk.ID] = snapshot
+	}
+
+	for _, event := range events {
+		snapshot, ok := snapshots[event.riskID]
+		if !ok {
+			return remediated, fmt.Errorf("remediate orphaned risks: snapshot missing for risk %s", event.riskID)
+		}
+		if err := s.logRiskEventWithSnapshot(tx, event.riskID, RiskEventTypeStatusChange, nil, event.payload, snapshot); err != nil {
+			return remediated, fmt.Errorf("remediate orphaned risks: emit event failed for risk %s: %w", event.riskID, err)
+		}
 	}
 
 	return remediated, nil

--- a/internal/service/relational/risks/service.go
+++ b/internal/service/relational/risks/service.go
@@ -1370,10 +1370,11 @@ type ControlKey struct {
 	ControlID string
 }
 
-// RemediateOrphanedRisks transitions all open, auto-generated risks for the
-// given SSP to remediated when none of their linked controls exist in
-// newProfileControlSet. Callers should pass a transaction when status updates
-// and emitted risk events must be committed atomically.
+// RemediateOrphanedRisks transitions all non-terminal auto-generated risks for
+// the given SSP to remediated when none of their linked controls exist in
+// newProfileControlSet. Closed and already-remediated risks are left untouched.
+// Callers should pass a transaction when status updates and emitted risk events
+// must be committed atomically.
 //
 // Pass an empty newProfileControlSet when the profile has been unbound entirely
 // (all auto-generated risks become orphaned by definition).
@@ -1442,7 +1443,13 @@ func (s *RiskService) RemediateOrphanedRisks(
 
 		riskControlKeys := riskControls[*risk.ID]
 		if len(riskControlKeys) == 0 {
-			continue
+			// Risks with no control links cannot be matched against a non-empty
+			// profile control set, so preserve the existing behavior for partial
+			// profile changes. During a full unbind, however, they should be
+			// treated as orphaned and remediated.
+			if len(normalisedProfileSet) > 0 {
+				continue
+			}
 		}
 
 		if len(normalisedProfileSet) > 0 {

--- a/internal/service/relational/risks/service.go
+++ b/internal/service/relational/risks/service.go
@@ -1387,8 +1387,9 @@ func (s *RiskService) RemediateOrphanedRisks(
 	var candidates []Risk
 	if err := tx.
 		Where(
-			"ssp_id = ? AND risk_template_id IS NOT NULL AND status NOT IN ?",
+			"ssp_id = ? AND risk_template_id IS NOT NULL AND source_type IN ? AND status NOT IN ?",
 			sspID,
+			[]string{string(RiskSourceTypeEvidenceAuto), string(RiskSourceTypeOscalImport)},
 			[]string{string(RiskStatusClosed), string(RiskStatusRemediated)},
 		).
 		Find(&candidates).Error; err != nil {
@@ -1427,8 +1428,6 @@ func (s *RiskService) RemediateOrphanedRisks(
 	}
 
 	remediated := 0
-	occurredAt := time.Now().UTC()
-
 	for i := range candidates {
 		risk := &candidates[i]
 		if risk.ID == nil {
@@ -1469,15 +1468,7 @@ func (s *RiskService) RemediateOrphanedRisks(
 			"to":     string(RiskStatusRemediated),
 			"reason": "orphaned_profile_change",
 		}
-		details := BuildRiskEventDetails(string(RiskEventTypeStatusChange), payload, occurredAt)
-		event := &RiskEvent{
-			RiskID:     *risk.ID,
-			EventType:  string(RiskEventTypeStatusChange),
-			OccurredAt: occurredAt,
-			Details:    &details,
-			Payload:    payload,
-		}
-		if err := tx.Create(event).Error; err != nil {
+		if err := s.logRiskEvent(tx, *risk.ID, RiskEventTypeStatusChange, nil, payload); err != nil {
 			return remediated, fmt.Errorf("remediate orphaned risks: emit event failed for risk %s: %w", *risk.ID, err)
 		}
 

--- a/internal/service/relational/risks/service.go
+++ b/internal/service/relational/risks/service.go
@@ -1372,8 +1372,8 @@ type ControlKey struct {
 
 // RemediateOrphanedRisks transitions all open, auto-generated risks for the
 // given SSP to remediated when none of their linked controls exist in
-// newProfileControlSet. It must be called inside the caller transaction (tx)
-// so that the profile update and the risk cleanup are atomic.
+// newProfileControlSet. Callers should pass a transaction when status updates
+// and emitted risk events must be committed atomically.
 //
 // Pass an empty newProfileControlSet when the profile has been unbound entirely
 // (all auto-generated risks become orphaned by definition).

--- a/internal/service/relational/risks/service.go
+++ b/internal/service/relational/risks/service.go
@@ -1465,8 +1465,14 @@ func (s *RiskService) RemediateOrphanedRisks(
 		}
 
 		oldStatus := risk.Status
-		if err := tx.Model(risk).Update("status", string(RiskStatusRemediated)).Error; err != nil {
-			return remediated, fmt.Errorf("remediate orphaned risks: update status failed for risk %s: %w", *risk.ID, err)
+		result := tx.Model(&Risk{}).
+			Where("id = ? AND status = ?", *risk.ID, oldStatus).
+			Update("status", string(RiskStatusRemediated))
+		if result.Error != nil {
+			return remediated, fmt.Errorf("remediate orphaned risks: update status failed for risk %s: %w", *risk.ID, result.Error)
+		}
+		if result.RowsAffected == 0 {
+			continue
 		}
 
 		payload := datatypes.JSONMap{

--- a/internal/service/worker/risk_job_types.go
+++ b/internal/service/worker/risk_job_types.go
@@ -148,9 +148,10 @@ func JobInsertOptionsForRiskDigest(byPeriod time.Duration) *river.InsertOpts {
 }
 
 // JobInsertOptionsForRiskOrphanedCleanup returns insert options for the orphaned risk cleanup job.
-// ByArgs deduplication ensures that each unique (ssp_id, new_profile_id) combination gets its own
-// job — multiple profile changes on the same SSP in the same day each produce an independent job.
-// No ByPeriod is set intentionally so that rapid successive changes are not collapsed.
+// ByArgs deduplication uses the river:"unique" fields on RiskOrphanedCleanupArgs, so active
+// jobs are unique by (ssp_id, new_profile_id). Repeated changes to the same target profile are
+// collapsed while an equivalent job is active; changes to different target profiles can enqueue
+// independent jobs.
 //
 // ByState is explicitly set to exclude JobStateCompleted and JobStateCancelled so that a second
 // profile change to the same target profile re-inserts a fresh cleanup job even if the previous

--- a/internal/service/worker/risk_job_types.go
+++ b/internal/service/worker/risk_job_types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 )
 
 const (
@@ -150,12 +151,23 @@ func JobInsertOptionsForRiskDigest(byPeriod time.Duration) *river.InsertOpts {
 // ByArgs deduplication ensures that each unique (ssp_id, new_profile_id) combination gets its own
 // job — multiple profile changes on the same SSP in the same day each produce an independent job.
 // No ByPeriod is set intentionally so that rapid successive changes are not collapsed.
+//
+// ByState is explicitly set to exclude JobStateCompleted and JobStateCancelled so that a second
+// profile change to the same target profile re-inserts a fresh cleanup job even if the previous
+// one completed but has not yet been removed by River's job-cleaner maintenance process.
 func JobInsertOptionsForRiskOrphanedCleanup() *river.InsertOpts {
 	return &river.InsertOpts{
 		Queue:       "risk",
 		MaxAttempts: 3,
 		UniqueOpts: river.UniqueOpts{
 			ByArgs: true,
+			ByState: []rivertype.JobState{
+				rivertype.JobStateAvailable,
+				rivertype.JobStatePending,
+				rivertype.JobStateRunning,
+				rivertype.JobStateRetryable,
+				rivertype.JobStateScheduled,
+			},
 		},
 	}
 }

--- a/internal/service/worker/risk_job_types.go
+++ b/internal/service/worker/risk_job_types.go
@@ -63,7 +63,8 @@ type RiskReviewOverdueReopenArgs struct {
 
 // RiskOrphanedCleanupArgs is enqueued by the SSP profile attach endpoint whenever the
 // profile binding changes. The worker resolves the current profile's control set and
-// transitions any open auto-generated risks whose controls are no longer present to remediated.
+// transitions any non-terminal auto-generated risks whose controls are no longer present
+// to remediated.
 //
 // Deduplication uses river:"unique" tags on ssp_id and new_profile_id only. OldProfileID
 // is kept for observability/logging but excluded from the uniqueness hash. This means:

--- a/internal/service/worker/risk_job_types.go
+++ b/internal/service/worker/risk_job_types.go
@@ -20,6 +20,7 @@ const (
 	JobTypeRiskReconcileDuplicates     = "risk_reconcile_duplicates"
 	JobTypeRiskReviewOverdueReopen     = "risk_review_overdue_reopen"
 	JobTypeRiskOpenDigest              = "risk_open_digest"
+	JobTypeRiskOrphanedCleanup         = "risk_orphaned_cleanup"
 )
 
 type RiskReviewDeadlineReminderScannerArgs struct{}
@@ -59,6 +60,20 @@ type RiskReviewOverdueReopenArgs struct {
 	ThresholdDays  int       `json:"threshold_days"`
 }
 
+// RiskOrphanedCleanupArgs is enqueued by the SSP profile attach/update endpoints whenever
+// the profile binding changes. The worker resolves the new profile's control set and
+// transitions any open auto-generated risks whose controls are no longer present to remediated.
+//
+// Deduplication uses river:"unique" tags on ssp_id and new_profile_id only. OldProfileID
+// is kept for observability/logging but excluded from the uniqueness hash. This means:
+//   - Two rapid changes to the same target profile → one job (correct: second is a no-op)
+//   - Two rapid changes to different target profiles → two independent jobs (correct)
+type RiskOrphanedCleanupArgs struct {
+	SSPID        uuid.UUID  `json:"ssp_id"                  river:"unique"`
+	OldProfileID *uuid.UUID `json:"old_profile_id,omitempty"`
+	NewProfileID *uuid.UUID `json:"new_profile_id,omitempty" river:"unique"`
+}
+
 type RiskOpenDigestArgs struct {
 	RecipientUserID uuid.UUID `json:"recipient_user_id"`
 	WindowStart     string    `json:"window_start"`
@@ -83,6 +98,7 @@ func (RiskStaleOpenReminderArgs) Kind() string       { return JobTypeRiskStaleOp
 func (RiskReconcileDuplicatesArgs) Kind() string     { return JobTypeRiskReconcileDuplicates }
 func (RiskReviewOverdueReopenArgs) Kind() string     { return JobTypeRiskReviewOverdueReopen }
 func (RiskOpenDigestArgs) Kind() string              { return JobTypeRiskOpenDigest }
+func (RiskOrphanedCleanupArgs) Kind() string         { return JobTypeRiskOrphanedCleanup }
 
 func (RiskReviewDeadlineReminderScannerArgs) Timeout() time.Duration  { return 5 * time.Minute }
 func (RiskReviewOverdueEscalationScannerArgs) Timeout() time.Duration { return 5 * time.Minute }
@@ -95,6 +111,7 @@ func (RiskStaleOpenReminderArgs) Timeout() time.Duration              { return 3
 func (RiskReconcileDuplicatesArgs) Timeout() time.Duration            { return 2 * time.Minute }
 func (RiskReviewOverdueReopenArgs) Timeout() time.Duration            { return 30 * time.Second }
 func (RiskOpenDigestArgs) Timeout() time.Duration                     { return 30 * time.Second }
+func (RiskOrphanedCleanupArgs) Timeout() time.Duration                { return 2 * time.Minute }
 
 func JobInsertOptionsForRiskNotification(byPeriod time.Duration) *river.InsertOpts {
 	return &river.InsertOpts{
@@ -125,6 +142,20 @@ func JobInsertOptionsForRiskDigest(byPeriod time.Duration) *river.InsertOpts {
 		UniqueOpts: river.UniqueOpts{
 			ByArgs:   true,
 			ByPeriod: byPeriod,
+		},
+	}
+}
+
+// JobInsertOptionsForRiskOrphanedCleanup returns insert options for the orphaned risk cleanup job.
+// ByArgs deduplication ensures that each unique (ssp_id, new_profile_id) combination gets its own
+// job — multiple profile changes on the same SSP in the same day each produce an independent job.
+// No ByPeriod is set intentionally so that rapid successive changes are not collapsed.
+func JobInsertOptionsForRiskOrphanedCleanup() *river.InsertOpts {
+	return &river.InsertOpts{
+		Queue:       "risk",
+		MaxAttempts: 3,
+		UniqueOpts: river.UniqueOpts{
+			ByArgs: true,
 		},
 	}
 }

--- a/internal/service/worker/risk_job_types.go
+++ b/internal/service/worker/risk_job_types.go
@@ -61,8 +61,8 @@ type RiskReviewOverdueReopenArgs struct {
 	ThresholdDays  int       `json:"threshold_days"`
 }
 
-// RiskOrphanedCleanupArgs is enqueued by the SSP profile attach/update endpoints whenever
-// the profile binding changes. The worker resolves the new profile's control set and
+// RiskOrphanedCleanupArgs is enqueued by the SSP profile attach endpoint whenever the
+// profile binding changes. The worker resolves the current profile's control set and
 // transitions any open auto-generated risks whose controls are no longer present to remediated.
 //
 // Deduplication uses river:"unique" tags on ssp_id and new_profile_id only. OldProfileID

--- a/internal/service/worker/risk_orphaned_cleanup_worker.go
+++ b/internal/service/worker/risk_orphaned_cleanup_worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/compliance-framework/api/internal/service/relational"
 	riskrel "github.com/compliance-framework/api/internal/service/relational/risks"
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
@@ -20,18 +21,18 @@ type ProfileControlResolver interface {
 }
 
 // RiskOrphanedCleanupWorker is enqueued by the SSP profile attach endpoint whenever the
-// profile binding changes. It resolves the new profile's full control set and transitions
-// any open auto-generated risks whose linked controls are no longer present in that set to
-// the "remediated" status.
+// profile binding changes. At execution time, it resolves the SSP's current profile control
+// set and transitions any open auto-generated risks whose linked controls are no longer
+// present in that set to the "remediated" status.
 //
 // Design rationale:
 //   - The handler enqueues a job rather than calling RemediateOrphanedRisks inline so that
 //     the HTTP response is not blocked by potentially expensive profile resolution.
-//   - River's ByArgs deduplication (scoped to ssp_id + new_profile_id) ensures that each
-//     unique profile change on an SSP produces its own job. ByState is overridden to exclude
-//     completed/cancelled jobs so that a second change to the same target profile within the
-//     River job-cleaner window still triggers a fresh cleanup pass.
-//   - No ByPeriod is set, so rapid successive changes are never silently collapsed.
+//   - River's ByArgs deduplication is scoped to ssp_id + new_profile_id. Active jobs for
+//     repeated changes to the same target profile are collapsed, while changes to different
+//     targets can enqueue independent jobs.
+//   - The worker reloads the current SSP profile at execution time so stale jobs remediate
+//     against the latest committed binding.
 type RiskOrphanedCleanupWorker struct {
 	db              *gorm.DB
 	riskService     *riskrel.RiskService
@@ -50,7 +51,7 @@ func NewRiskOrphanedCleanupWorker(db *gorm.DB, riskService *riskrel.RiskService,
 	}
 }
 
-// Work implements river.Worker. It resolves the new profile's control set and delegates
+// Work implements river.Worker. It resolves the current profile's control set and delegates
 // to RiskService.RemediateOrphanedRisks.
 func (w *RiskOrphanedCleanupWorker) Work(ctx context.Context, job *river.Job[RiskOrphanedCleanupArgs]) error {
 	args := job.Args
@@ -60,13 +61,28 @@ func (w *RiskOrphanedCleanupWorker) Work(ctx context.Context, job *river.Job[Ris
 		"new_profile_id", args.NewProfileID,
 	)
 
-	// Build the new profile's control set.
-	// If NewProfileID is nil the SSP's profile binding was cleared — all auto-generated
-	// risks are orphaned by definition, so we pass an empty set.
+	db := w.db.WithContext(ctx)
+
+	var ssp relational.SystemSecurityPlan
+	if err := db.Select("id", "profile_id").First(&ssp, "id = ?", args.SSPID).Error; err != nil {
+		return fmt.Errorf("risk orphaned cleanup: load current ssp %s: %w", args.SSPID, err)
+	}
+
+	if !uuidPtrEqual(ssp.ProfileID, args.NewProfileID) {
+		w.logger.Infow("risk orphaned cleanup: job profile is stale, using current SSP profile",
+			"ssp_id", args.SSPID,
+			"job_new_profile_id", args.NewProfileID,
+			"current_profile_id", ssp.ProfileID,
+		)
+	}
+
+	// Build the current profile's control set.
+	// If ProfileID is nil the SSP's profile binding was cleared, so all auto-generated
+	// risks are orphaned by definition and we pass an empty set.
 	newControlSet := make(map[riskrel.ControlKey]struct{})
 
-	if args.NewProfileID != nil {
-		controlKeys, err := w.profileResolver.ResolveProfileControlKeys(ctx, *args.NewProfileID)
+	if ssp.ProfileID != nil {
+		controlKeys, err := w.profileResolver.ResolveProfileControlKeys(ctx, *ssp.ProfileID)
 		if err != nil {
 			return fmt.Errorf("risk orphaned cleanup: resolve profile controls for ssp %s: %w", args.SSPID, err)
 		}
@@ -75,8 +91,12 @@ func (w *RiskOrphanedCleanupWorker) Work(ctx context.Context, job *river.Job[Ris
 		}
 	}
 
-	remediated, err := w.riskService.RemediateOrphanedRisks(w.db.WithContext(ctx), args.SSPID, newControlSet)
-	if err != nil {
+	var remediated int
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		var err error
+		remediated, err = w.riskService.RemediateOrphanedRisks(tx, args.SSPID, newControlSet)
+		return err
+	}); err != nil {
 		return fmt.Errorf("risk orphaned cleanup: remediate for ssp %s: %w", args.SSPID, err)
 	}
 
@@ -85,4 +105,15 @@ func (w *RiskOrphanedCleanupWorker) Work(ctx context.Context, job *river.Job[Ris
 		"remediated_count", remediated,
 	)
 	return nil
+}
+
+func uuidPtrEqual(a, b *uuid.UUID) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil || b == nil:
+		return false
+	default:
+		return *a == *b
+	}
 }

--- a/internal/service/worker/risk_orphaned_cleanup_worker.go
+++ b/internal/service/worker/risk_orphaned_cleanup_worker.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/compliance-framework/api/internal/service/relational"
@@ -65,6 +66,14 @@ func (w *RiskOrphanedCleanupWorker) Work(ctx context.Context, job *river.Job[Ris
 
 	var ssp relational.SystemSecurityPlan
 	if err := db.Select("id", "profile_id").First(&ssp, "id = ?", args.SSPID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			w.logger.Infow("risk orphaned cleanup: ssp not found, skipping",
+				"ssp_id", args.SSPID,
+				"old_profile_id", args.OldProfileID,
+				"new_profile_id", args.NewProfileID,
+			)
+			return nil
+		}
 		return fmt.Errorf("risk orphaned cleanup: load current ssp %s: %w", args.SSPID, err)
 	}
 

--- a/internal/service/worker/risk_orphaned_cleanup_worker.go
+++ b/internal/service/worker/risk_orphaned_cleanup_worker.go
@@ -1,0 +1,115 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	riskrel "github.com/compliance-framework/api/internal/service/relational/risks"
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// RiskOrphanedCleanupWorker is enqueued synchronously by the SSP profile attach/update
+// endpoints whenever the profile binding changes. It resolves the new profile's full control
+// set and transitions any open auto-generated risks whose linked controls are no longer
+// present in that set to the "remediated" status.
+//
+// Design rationale:
+//   - The handler enqueues a job rather than calling RemediateOrphanedRisks inline so that
+//     the HTTP response is not blocked by potentially expensive profile resolution.
+//   - River's ByArgs deduplication ensures that each unique (ssp_id, new_profile_id) pair
+//     produces its own job, so multiple profile changes on the same SSP within a short window
+//     each trigger an independent cleanup pass.
+//   - No ByPeriod is set, so rapid successive changes are never silently collapsed.
+type RiskOrphanedCleanupWorker struct {
+	db          *gorm.DB
+	riskService *riskrel.RiskService
+	logger      *zap.SugaredLogger
+}
+
+// NewRiskOrphanedCleanupWorker constructs a RiskOrphanedCleanupWorker.
+func NewRiskOrphanedCleanupWorker(db *gorm.DB, riskService *riskrel.RiskService, logger *zap.SugaredLogger) *RiskOrphanedCleanupWorker {
+	return &RiskOrphanedCleanupWorker{
+		db:          db,
+		riskService: riskService,
+		logger:      logger,
+	}
+}
+
+// Work implements river.Worker. It resolves the new profile's control set and delegates
+// to RiskService.RemediateOrphanedRisks.
+func (w *RiskOrphanedCleanupWorker) Work(ctx context.Context, job *river.Job[RiskOrphanedCleanupArgs]) error {
+	args := job.Args
+	w.logger.Infow("risk orphaned cleanup: starting",
+		"ssp_id", args.SSPID,
+		"old_profile_id", args.OldProfileID,
+		"new_profile_id", args.NewProfileID,
+	)
+
+	// Build the new profile's control set.
+	// If NewProfileID is nil the SSP's profile binding was cleared — all auto-generated
+	// risks are orphaned, so we pass an empty set.
+	newControlSet := make(map[riskrel.ControlKey]struct{})
+
+	if args.NewProfileID != nil {
+		controlIDs, err := w.resolveProfileControlIDs(ctx, *args.NewProfileID)
+		if err != nil {
+			return fmt.Errorf("risk orphaned cleanup: resolve profile controls for ssp %s: %w", args.SSPID, err)
+		}
+		for _, id := range controlIDs {
+			newControlSet[riskrel.ControlKey{ControlID: id}] = struct{}{}
+		}
+	}
+
+	remediated, err := w.riskService.RemediateOrphanedRisks(w.db.WithContext(ctx), args.SSPID, newControlSet)
+	if err != nil {
+		return fmt.Errorf("risk orphaned cleanup: remediate for ssp %s: %w", args.SSPID, err)
+	}
+
+	w.logger.Infow("risk orphaned cleanup: complete",
+		"ssp_id", args.SSPID,
+		"remediated_count", remediated,
+	)
+	return nil
+}
+
+// resolveProfileControlIDs returns all control IDs for a given profile using the same
+// two-step resolution as the SSP handler:
+//  1. Pivot table (profile_controls) — fast path, populated by SyncProfileControls
+//  2. Direct join through the profile → controls many2many — fallback when pivot is empty
+func (w *RiskOrphanedCleanupWorker) resolveProfileControlIDs(ctx context.Context, profileID uuid.UUID) ([]string, error) {
+	// Step 1: pivot table (fast path)
+	var controlIDs []string
+	if err := w.db.WithContext(ctx).
+		Table("profile_controls").
+		Distinct("control_id").
+		Where("profile_id = ?", profileID).
+		Pluck("control_id", &controlIDs).Error; err != nil {
+		w.logger.Warnw("risk orphaned cleanup: pivot table lookup failed, falling back to join",
+			"profile_id", profileID, "error", err)
+	}
+
+	if len(controlIDs) > 0 {
+		return controlIDs, nil
+	}
+
+	// Step 2: direct join — profile_controls may not be populated yet for new profiles
+	// (SyncProfileControls runs asynchronously). Fall back to querying the join table
+	// that backs the Profile.Controls many2many association.
+	w.logger.Infow("risk orphaned cleanup: pivot table empty, falling back to direct join",
+		"profile_id", profileID)
+
+	if err := w.db.WithContext(ctx).
+		Table("profile_controls").
+		Distinct("control_id").
+		Where("profile_id IN (?)",
+			w.db.Table("profiles").Select("id").Where("id = ?", profileID),
+		).
+		Pluck("control_id", &controlIDs).Error; err != nil {
+		return nil, fmt.Errorf("resolveProfileControlIDs: direct join query failed: %w", err)
+	}
+
+	return controlIDs, nil
+}

--- a/internal/service/worker/risk_orphaned_cleanup_worker.go
+++ b/internal/service/worker/risk_orphaned_cleanup_worker.go
@@ -23,8 +23,8 @@ type ProfileControlResolver interface {
 
 // RiskOrphanedCleanupWorker is enqueued by the SSP profile attach endpoint whenever the
 // profile binding changes. At execution time, it resolves the SSP's current profile control
-// set and transitions any open auto-generated risks whose linked controls are no longer
-// present in that set to the "remediated" status.
+// set and transitions any non-terminal auto-generated risks whose linked controls are no
+// longer present in that set to the "remediated" status.
 //
 // Design rationale:
 //   - The handler enqueues a job rather than calling RemediateOrphanedRisks inline so that

--- a/internal/service/worker/risk_orphaned_cleanup_worker.go
+++ b/internal/service/worker/risk_orphaned_cleanup_worker.go
@@ -11,30 +11,42 @@ import (
 	"gorm.io/gorm"
 )
 
-// RiskOrphanedCleanupWorker is enqueued synchronously by the SSP profile attach/update
-// endpoints whenever the profile binding changes. It resolves the new profile's full control
-// set and transitions any open auto-generated risks whose linked controls are no longer
-// present in that set to the "remediated" status.
+// ProfileControlResolver resolves the full set of (catalogID, controlID) pairs for a profile.
+// Defined as an interface to avoid a circular import between the worker and oscal handler packages.
+// The implementation is injected at wire-up time in cmd/run.go using a closure over
+// oscalhandler.FindFullProfile and oscalhandler.GetControlIDsMapFromProfile.
+type ProfileControlResolver interface {
+	ResolveProfileControlKeys(ctx context.Context, profileID uuid.UUID) ([]riskrel.ControlKey, error)
+}
+
+// RiskOrphanedCleanupWorker is enqueued by the SSP profile attach endpoint whenever the
+// profile binding changes. It resolves the new profile's full control set and transitions
+// any open auto-generated risks whose linked controls are no longer present in that set to
+// the "remediated" status.
 //
 // Design rationale:
 //   - The handler enqueues a job rather than calling RemediateOrphanedRisks inline so that
 //     the HTTP response is not blocked by potentially expensive profile resolution.
-//   - River's ByArgs deduplication ensures that each unique (ssp_id, new_profile_id) pair
-//     produces its own job, so multiple profile changes on the same SSP within a short window
-//     each trigger an independent cleanup pass.
+//   - River's ByArgs deduplication (scoped to ssp_id + new_profile_id) ensures that each
+//     unique profile change on an SSP produces its own job. ByState is overridden to exclude
+//     completed/cancelled jobs so that a second change to the same target profile within the
+//     River job-cleaner window still triggers a fresh cleanup pass.
 //   - No ByPeriod is set, so rapid successive changes are never silently collapsed.
 type RiskOrphanedCleanupWorker struct {
-	db          *gorm.DB
-	riskService *riskrel.RiskService
-	logger      *zap.SugaredLogger
+	db              *gorm.DB
+	riskService     *riskrel.RiskService
+	profileResolver ProfileControlResolver
+	logger          *zap.SugaredLogger
 }
 
 // NewRiskOrphanedCleanupWorker constructs a RiskOrphanedCleanupWorker.
-func NewRiskOrphanedCleanupWorker(db *gorm.DB, riskService *riskrel.RiskService, logger *zap.SugaredLogger) *RiskOrphanedCleanupWorker {
+// profileResolver must be non-nil; it is injected from cmd/run.go to avoid a circular import.
+func NewRiskOrphanedCleanupWorker(db *gorm.DB, riskService *riskrel.RiskService, profileResolver ProfileControlResolver, logger *zap.SugaredLogger) *RiskOrphanedCleanupWorker {
 	return &RiskOrphanedCleanupWorker{
-		db:          db,
-		riskService: riskService,
-		logger:      logger,
+		db:              db,
+		riskService:     riskService,
+		profileResolver: profileResolver,
+		logger:          logger,
 	}
 }
 
@@ -50,16 +62,16 @@ func (w *RiskOrphanedCleanupWorker) Work(ctx context.Context, job *river.Job[Ris
 
 	// Build the new profile's control set.
 	// If NewProfileID is nil the SSP's profile binding was cleared — all auto-generated
-	// risks are orphaned, so we pass an empty set.
+	// risks are orphaned by definition, so we pass an empty set.
 	newControlSet := make(map[riskrel.ControlKey]struct{})
 
 	if args.NewProfileID != nil {
-		controlIDs, err := w.resolveProfileControlIDs(ctx, *args.NewProfileID)
+		controlKeys, err := w.profileResolver.ResolveProfileControlKeys(ctx, *args.NewProfileID)
 		if err != nil {
 			return fmt.Errorf("risk orphaned cleanup: resolve profile controls for ssp %s: %w", args.SSPID, err)
 		}
-		for _, id := range controlIDs {
-			newControlSet[riskrel.ControlKey{ControlID: id}] = struct{}{}
+		for _, ck := range controlKeys {
+			newControlSet[ck] = struct{}{}
 		}
 	}
 
@@ -73,43 +85,4 @@ func (w *RiskOrphanedCleanupWorker) Work(ctx context.Context, job *river.Job[Ris
 		"remediated_count", remediated,
 	)
 	return nil
-}
-
-// resolveProfileControlIDs returns all control IDs for a given profile using the same
-// two-step resolution as the SSP handler:
-//  1. Pivot table (profile_controls) — fast path, populated by SyncProfileControls
-//  2. Direct join through the profile → controls many2many — fallback when pivot is empty
-func (w *RiskOrphanedCleanupWorker) resolveProfileControlIDs(ctx context.Context, profileID uuid.UUID) ([]string, error) {
-	// Step 1: pivot table (fast path)
-	var controlIDs []string
-	if err := w.db.WithContext(ctx).
-		Table("profile_controls").
-		Distinct("control_id").
-		Where("profile_id = ?", profileID).
-		Pluck("control_id", &controlIDs).Error; err != nil {
-		w.logger.Warnw("risk orphaned cleanup: pivot table lookup failed, falling back to join",
-			"profile_id", profileID, "error", err)
-	}
-
-	if len(controlIDs) > 0 {
-		return controlIDs, nil
-	}
-
-	// Step 2: direct join — profile_controls may not be populated yet for new profiles
-	// (SyncProfileControls runs asynchronously). Fall back to querying the join table
-	// that backs the Profile.Controls many2many association.
-	w.logger.Infow("risk orphaned cleanup: pivot table empty, falling back to direct join",
-		"profile_id", profileID)
-
-	if err := w.db.WithContext(ctx).
-		Table("profile_controls").
-		Distinct("control_id").
-		Where("profile_id IN (?)",
-			w.db.Table("profiles").Select("id").Where("id = ?", profileID),
-		).
-		Pluck("control_id", &controlIDs).Error; err != nil {
-		return nil, fmt.Errorf("resolveProfileControlIDs: direct join query failed: %w", err)
-	}
-
-	return controlIDs, nil
 }

--- a/internal/service/worker/risk_orphaned_cleanup_worker_test.go
+++ b/internal/service/worker/risk_orphaned_cleanup_worker_test.go
@@ -37,6 +37,7 @@ func createOrphanedCleanupRisk(t *testing.T, db *gorm.DB, sspID uuid.UUID, contr
 		Status:         string(riskrel.RiskStatusOpen),
 		SSPID:          sspID,
 		RiskTemplateID: &templateID,
+		SourceType:     string(riskrel.RiskSourceTypeEvidenceAuto),
 	}).Error)
 	require.NoError(t, db.Create(&riskrel.RiskControlLink{
 		RiskID:    riskID,
@@ -113,4 +114,22 @@ func TestRiskOrphanedCleanupWorker_CurrentProfileUnboundRemediatesAllAutoRisks(t
 	var eventCount int64
 	require.NoError(t, db.Model(&riskrel.RiskEvent{}).Where("risk_id = ?", riskID).Count(&eventCount).Error)
 	assert.Equal(t, int64(1), eventCount)
+}
+
+func TestRiskOrphanedCleanupWorker_MissingSSPSkipsWithoutRetry(t *testing.T) {
+	db := newRiskWorkersTestDB(t)
+	profileID := uuid.New()
+	resolver := &stubProfileControlResolver{
+		controls: map[uuid.UUID][]riskrel.ControlKey{
+			profileID: {{ControlID: "AC-1"}},
+		},
+	}
+	worker := NewRiskOrphanedCleanupWorker(db, riskrel.NewRiskService(db), resolver, zap.NewNop().Sugar())
+
+	err := worker.Work(context.Background(), makeWorkerJob(RiskOrphanedCleanupArgs{
+		SSPID:        uuid.New(),
+		NewProfileID: &profileID,
+	}))
+	require.NoError(t, err)
+	assert.Empty(t, resolver.calls)
 }

--- a/internal/service/worker/risk_orphaned_cleanup_worker_test.go
+++ b/internal/service/worker/risk_orphaned_cleanup_worker_test.go
@@ -1,0 +1,116 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/compliance-framework/api/internal/service/relational"
+	riskrel "github.com/compliance-framework/api/internal/service/relational/risks"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+type stubProfileControlResolver struct {
+	controls map[uuid.UUID][]riskrel.ControlKey
+	calls    []uuid.UUID
+}
+
+func (s *stubProfileControlResolver) ResolveProfileControlKeys(_ context.Context, profileID uuid.UUID) ([]riskrel.ControlKey, error) {
+	s.calls = append(s.calls, profileID)
+	return s.controls[profileID], nil
+}
+
+func createOrphanedCleanupRisk(t *testing.T, db *gorm.DB, sspID uuid.UUID, controlID string) uuid.UUID {
+	t.Helper()
+
+	riskID := uuid.New()
+	templateID := uuid.New()
+	catalogID := uuid.New()
+
+	require.NoError(t, db.Create(&riskrel.Risk{
+		UUIDModel:      relational.UUIDModel{ID: &riskID},
+		Title:          "Auto-generated risk",
+		Description:    "Risk created from remediation template",
+		Status:         string(riskrel.RiskStatusOpen),
+		SSPID:          sspID,
+		RiskTemplateID: &templateID,
+	}).Error)
+	require.NoError(t, db.Create(&riskrel.RiskControlLink{
+		RiskID:    riskID,
+		CatalogID: catalogID,
+		ControlID: controlID,
+	}).Error)
+
+	return riskID
+}
+
+func TestRiskOrphanedCleanupWorker_UsesCurrentSSPProfileForStaleJob(t *testing.T) {
+	db := newRiskWorkersTestDB(t)
+	sspID := uuid.New()
+	staleProfileID := uuid.New()
+	currentProfileID := uuid.New()
+
+	require.NoError(t, db.Create(&relational.SystemSecurityPlan{
+		UUIDModel: relational.UUIDModel{ID: &sspID},
+		ProfileID: &currentProfileID,
+	}).Error)
+	riskID := createOrphanedCleanupRisk(t, db, sspID, "AC-1")
+
+	resolver := &stubProfileControlResolver{
+		controls: map[uuid.UUID][]riskrel.ControlKey{
+			currentProfileID: {{ControlID: "AC-1"}},
+			staleProfileID:   {{ControlID: "AC-2"}},
+		},
+	}
+	worker := NewRiskOrphanedCleanupWorker(db, riskrel.NewRiskService(db), resolver, zap.NewNop().Sugar())
+
+	err := worker.Work(context.Background(), makeWorkerJob(RiskOrphanedCleanupArgs{
+		SSPID:        sspID,
+		NewProfileID: &staleProfileID,
+	}))
+	require.NoError(t, err)
+
+	assert.Equal(t, []uuid.UUID{currentProfileID}, resolver.calls)
+
+	var risk riskrel.Risk
+	require.NoError(t, db.First(&risk, "id = ?", riskID).Error)
+	assert.Equal(t, string(riskrel.RiskStatusOpen), risk.Status)
+}
+
+func TestRiskOrphanedCleanupWorker_CurrentProfileUnboundRemediatesAllAutoRisks(t *testing.T) {
+	db := newRiskWorkersTestDB(t)
+	sspID := uuid.New()
+	staleProfileID := uuid.New()
+
+	require.NoError(t, db.Create(&relational.SystemSecurityPlan{
+		UUIDModel: relational.UUIDModel{ID: &sspID},
+		ProfileID: nil,
+	}).Error)
+	riskID := createOrphanedCleanupRisk(t, db, sspID, "AC-1")
+
+	resolver := &stubProfileControlResolver{
+		controls: map[uuid.UUID][]riskrel.ControlKey{
+			staleProfileID: {{ControlID: "AC-1"}},
+		},
+	}
+	worker := NewRiskOrphanedCleanupWorker(db, riskrel.NewRiskService(db), resolver, zap.NewNop().Sugar())
+
+	err := worker.Work(context.Background(), makeWorkerJob(RiskOrphanedCleanupArgs{
+		SSPID:        sspID,
+		NewProfileID: &staleProfileID,
+	}))
+	require.NoError(t, err)
+
+	assert.Empty(t, resolver.calls)
+
+	var risk riskrel.Risk
+	require.NoError(t, db.First(&risk, "id = ?", riskID).Error)
+	assert.Equal(t, string(riskrel.RiskStatusRemediated), risk.Status)
+
+	var eventCount int64
+	require.NoError(t, db.Model(&riskrel.RiskEvent{}).Where("risk_id = ?", riskID).Count(&eventCount).Error)
+	assert.Equal(t, int64(1), eventCount)
+}

--- a/internal/service/worker/risk_workers_test.go
+++ b/internal/service/worker/risk_workers_test.go
@@ -62,6 +62,7 @@ func newRiskWorkersTestDB(t *testing.T) *gorm.DB {
 		&relational.InventoryItem{},
 		&riskrel.Risk{},
 		&riskrel.RiskOwnerAssignment{},
+		&riskrel.RiskControlLink{},
 		&riskrel.RiskEvidenceLink{},
 		&riskrel.RiskSubjectLink{},
 		&riskrel.RiskThreatRef{},

--- a/internal/service/worker/service.go
+++ b/internal/service/worker/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/compliance-framework/api/internal/config"
 	"github.com/compliance-framework/api/internal/service/email"
+	riskrel "github.com/compliance-framework/api/internal/service/relational/risks"
 	"github.com/compliance-framework/api/internal/service/relational/workflows"
 	slacksvc "github.com/compliance-framework/api/internal/service/slack"
 	"github.com/compliance-framework/api/internal/workflow"
@@ -293,6 +294,10 @@ func NewServiceWithDigest(
 
 	riskOpenDigestSchedulerWorker := NewRiskOpenDigestSchedulerWorker(db, clientProxy, riskCfg.OpenDigestWindow, logger)
 	river.AddWorker(workers, river.WorkFunc(riskOpenDigestSchedulerWorker.Work))
+
+	// Add orphaned risk cleanup worker — triggered on-demand when SSP profile binding changes
+	riskOrphanedCleanupWorker := NewRiskOrphanedCleanupWorker(db, riskrel.NewRiskService(db), logger)
+	river.AddWorker(workers, river.WorkFunc(riskOrphanedCleanupWorker.Work))
 
 	// Add POAM scanner workers (BCH-1186 Phase 3)
 	poamCfg := config.DefaultPoamConfig()
@@ -902,5 +907,27 @@ func (s *Service) EnqueueRiskProcessEvidence(ctx context.Context, evidenceID uui
 		return fmt.Errorf("failed to enqueue risk process evidence job: %w", err)
 	}
 
+	return nil
+}
+
+// EnqueueOrphanedRiskCleanup enqueues a job to remediate orphaned risks when an SSP's
+// profile binding changes. Each unique (ssp_id, new_profile_id) combination produces
+// an independent job — multiple profile changes on the same SSP in a short window
+// each trigger their own cleanup pass.
+func (s *Service) EnqueueOrphanedRiskCleanup(ctx context.Context, sspID uuid.UUID, oldProfileID, newProfileID *uuid.UUID) error {
+	if !s.config.Enabled || s.client == nil {
+		return nil
+	}
+	args := RiskOrphanedCleanupArgs{
+		SSPID:        sspID,
+		OldProfileID: oldProfileID,
+		NewProfileID: newProfileID,
+	}
+	_, err := s.client.InsertMany(ctx, []river.InsertManyParams{
+		{Args: args, InsertOpts: JobInsertOptionsForRiskOrphanedCleanup()},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to enqueue orphaned risk cleanup job for ssp %s: %w", sspID, err)
+	}
 	return nil
 }

--- a/internal/service/worker/service.go
+++ b/internal/service/worker/service.go
@@ -107,13 +107,16 @@ func (p *notificationEnqueuerProxy) EnqueueWorkflowExecutionFailed(ctx context.C
 	return p.enqueuer.EnqueueWorkflowExecutionFailed(ctx, execution)
 }
 
-// NewServiceWithDigest creates a new worker service with digest support
+// NewServiceWithDigest creates a new worker service with digest support.
+// profileResolver is injected to resolve profile control keys for the orphaned risk cleanup worker;
+// it must implement ProfileControlResolver and is typically a closure over oscal handler functions.
 func NewServiceWithDigest(
 	cfg *config.WorkerConfig,
 	db *gorm.DB,
 	emailSvc *email.Service,
 	digestSvc DigestService,
 	digestCfg *config.Config,
+	profileResolver ProfileControlResolver,
 	logger *zap.SugaredLogger,
 ) (*Service, error) {
 	if !cfg.Enabled {
@@ -296,7 +299,7 @@ func NewServiceWithDigest(
 	river.AddWorker(workers, river.WorkFunc(riskOpenDigestSchedulerWorker.Work))
 
 	// Add orphaned risk cleanup worker — triggered on-demand when SSP profile binding changes
-	riskOrphanedCleanupWorker := NewRiskOrphanedCleanupWorker(db, riskrel.NewRiskService(db), logger)
+	riskOrphanedCleanupWorker := NewRiskOrphanedCleanupWorker(db, riskrel.NewRiskService(db), profileResolver, logger)
 	river.AddWorker(workers, river.WorkFunc(riskOrphanedCleanupWorker.Work))
 
 	// Add POAM scanner workers (BCH-1186 Phase 3)

--- a/internal/service/worker/service.go
+++ b/internal/service/worker/service.go
@@ -135,6 +135,9 @@ func NewServiceWithDigest(
 	if emailSvc == nil {
 		return nil, fmt.Errorf("email service is required for worker service")
 	}
+	if profileResolver == nil {
+		return nil, fmt.Errorf("profile control resolver is required for worker service")
+	}
 
 	// Get pgx pool from GORM
 	// Note: Creating a separate pgx pool for River workers is acceptable here because:
@@ -914,9 +917,9 @@ func (s *Service) EnqueueRiskProcessEvidence(ctx context.Context, evidenceID uui
 }
 
 // EnqueueOrphanedRiskCleanup enqueues a job to remediate orphaned risks when an SSP's
-// profile binding changes. Each unique (ssp_id, new_profile_id) combination produces
-// an independent job — multiple profile changes on the same SSP in a short window
-// each trigger their own cleanup pass.
+// profile binding changes. Active jobs are deduped by (ssp_id, new_profile_id): repeated
+// changes to the same target profile collapse to one job, while changes to different
+// target profiles can produce independent jobs.
 func (s *Service) EnqueueOrphanedRiskCleanup(ctx context.Context, sspID uuid.UUID, oldProfileID, newProfileID *uuid.UUID) error {
 	if !s.config.Enabled || s.client == nil {
 		return nil

--- a/internal/service/worker/service_test.go
+++ b/internal/service/worker/service_test.go
@@ -84,7 +84,7 @@ func TestNewServiceWithDigest_Disabled(t *testing.T) {
 	}
 	logger := zap.NewNop().Sugar()
 
-	service, err := NewServiceWithDigest(cfg, nil, nil, nil, nil, logger)
+	service, err := NewServiceWithDigest(cfg, nil, nil, nil, nil, nil, logger)
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
 	assert.False(t, service.IsStarted())
@@ -98,7 +98,7 @@ func TestNewServiceWithDigest_RequiresEmailService(t *testing.T) {
 	}
 	logger := zap.NewNop().Sugar()
 
-	service, err := NewServiceWithDigest(cfg, nil, nil, nil, nil, logger)
+	service, err := NewServiceWithDigest(cfg, nil, nil, nil, nil, nil, logger)
 	assert.Error(t, err)
 	assert.Nil(t, service)
 	assert.Contains(t, err.Error(), "email service is required")
@@ -110,7 +110,7 @@ func TestService_EnqueueWhenDisabled(t *testing.T) {
 	}
 	logger := zap.NewNop().Sugar()
 
-	service, err := NewServiceWithDigest(cfg, nil, nil, nil, nil, logger)
+	service, err := NewServiceWithDigest(cfg, nil, nil, nil, nil, nil, logger)
 	assert.NoError(t, err)
 
 	ctx := context.Background()

--- a/internal/service/worker/service_test.go
+++ b/internal/service/worker/service_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/compliance-framework/api/internal/config"
+	"github.com/compliance-framework/api/internal/service/email"
 	"github.com/compliance-framework/api/internal/service/email/types"
 	"github.com/compliance-framework/api/internal/service/notification"
 	slacktypes "github.com/compliance-framework/api/internal/service/slack/types"
@@ -102,6 +103,20 @@ func TestNewServiceWithDigest_RequiresEmailService(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, service)
 	assert.Contains(t, err.Error(), "email service is required")
+}
+
+func TestNewServiceWithDigest_RequiresProfileResolver(t *testing.T) {
+	cfg := &config.WorkerConfig{
+		Enabled: true,
+		Workers: 5,
+		Queue:   "email",
+	}
+	logger := zap.NewNop().Sugar()
+
+	service, err := NewServiceWithDigest(cfg, nil, &email.Service{}, nil, nil, nil, logger)
+	assert.Error(t, err)
+	assert.Nil(t, service)
+	assert.Contains(t, err.Error(), "profile control resolver is required")
 }
 
 func TestService_EnqueueWhenDisabled(t *testing.T) {


### PR DESCRIPTION
### Summary
When an SSP's profile binding changes via `AttachProfile`, any auto-generated risks whose linked controls are no longer present in the current profile become orphaned. This PR implements asynchronous cleanup of those risks using a River background job, replacing an earlier approach that called `RemediateOrphanedRisks` synchronously inside the HTTP request path.

### Solution
The profile attach endpoint now enqueues a `RiskOrphanedCleanupArgs` River job after its transaction commits. The worker runs asynchronously and reloads the SSP's current `ProfileID` at execution time before resolving controls, so stale queued jobs remediate against the latest committed profile binding.

`UpdateImportProfile` only updates the OSCAL `import-profile.href` metadata field. It does not change the `ssp.ProfileID` foreign key, so it does not add/remove controls and does not enqueue orphaned-risk cleanup.

### Changes

**`internal/service/worker/risk_job_types.go`**
- Added `JobTypeRiskOrphanedCleanup` constant
- Added `RiskOrphanedCleanupArgs` struct with `river:"unique"` tags on `ssp_id` and `new_profile_id` only; `old_profile_id` is retained for observability but excluded from the deduplication hash
- Added `JobInsertOptionsForRiskOrphanedCleanup`: `risk` queue, `MaxAttempts: 3`, `ByArgs: true`, no `ByPeriod`, and `ByState` scoped to active job states

**`internal/service/worker/risk_orphaned_cleanup_worker.go`**
- Added `RiskOrphanedCleanupWorker`
- Reloads the SSP's current `ProfileID` at execution time to avoid stale queued jobs applying cleanup against an outdated profile
- Resolves the current profile's control set via the injected `ProfileControlResolver`
- Treats a current nil `ProfileID` as a full profile unbind, so all open auto-generated risks for the SSP are remediated
- Runs `RiskService.RemediateOrphanedRisks` inside a transaction so status updates and risk events commit atomically

**`internal/service/worker/service.go`**
- Registers `RiskOrphanedCleanupWorker`
- Validates that enabled workers receive a non-nil profile-control resolver
- Added `EnqueueOrphanedRiskCleanup(ctx, sspID, oldProfileID, newProfileID)`

**`internal/service/relational/risks/service.go`**
- Added `ControlKey`
- Added `RemediateOrphanedRisks`

**`internal/api/handler/oscal/system_security_plans.go`**
- Added `SSPJobEnqueuer` interface in the OSCAL package to avoid a circular import
- Removed the no-longer-needed `riskService` field from `SystemSecurityPlanHandler`
- `AttachProfile`: enqueues cleanup after transaction commit; enqueue failure is non-fatal and logged
- `UpdateImportProfile`: documents that this endpoint only updates import-profile metadata and does not enqueue cleanup

**`internal/api/handler/oscal/api.go`**
- `RegisterHandlers` signature updated to accept `SSPJobEnqueuer`

**`cmd/run.go` and `cmd/profile_control_resolver.go`**
- Added and wired an OSCAL profile-control resolver
- `workerService` is passed as `SSPJobEnqueuer` to `oscal.RegisterHandlers`

### Deduplication design
`ByArgs` deduplication is scoped to `(ssp_id, new_profile_id)` only via `river:"unique"` struct tags. This means:

- Two active jobs for the same SSP and same target profile collapse to one job
- Changes to different target profiles can enqueue independent jobs
- `old_profile_id` is intentionally excluded from the hash because it is only observability context
- Completed and cancelled jobs are excluded from the uniqueness states, so a later change to the same target profile can enqueue a fresh cleanup pass

The worker still reloads the current SSP profile before remediation. This means even if an older job runs after a later profile change, cleanup is based on the latest committed binding.
