### PR TITLE
fix: normalize password auth method to user type in can-transition

### DIFF
--- a/internal/api/handler/workflows/step_execution.go
+++ b/internal/api/handler/workflows/step_execution.go
@@ -406,6 +406,12 @@ func (h *StepExecutionHandler) CanTransition(ctx echo.Context) error {
 		return ctx.JSON(http.StatusBadRequest, api.NewError(echo.NewHTTPError(http.StatusBadRequest, "user_id and user_type are required")))
 	}
 
+	// "password" is an auth method, not an assignment type — password-authenticated
+	// users are always of assignment type "user".
+	if userType == "password" {
+		userType = workflows.AssignmentTypeUser.String()
+	}
+
 	canTransition, err := h.transitionService.CanUserTransitionStep(id, userID, userType)
 	if err != nil {
 		return h.HandleServiceError(ctx, err, "check", "transition permission")

--- a/internal/api/handler/workflows/step_execution_integration_test.go
+++ b/internal/api/handler/workflows/step_execution_integration_test.go
@@ -930,6 +930,139 @@ func TestStepExecutionHandler_ListMy(t *testing.T) {
 	})
 }
 
+func TestStepExecutionHandler_CanTransition(t *testing.T) {
+	handler, db := setupStepExecutionTestHandler(t)
+	e := echo.New()
+
+	workflowDef := &workflows.WorkflowDefinition{
+		Name:    "CanTransition Workflow",
+		Version: "1.0",
+	}
+	require.NoError(t, db.Create(workflowDef).Error)
+
+	sysID := uuid.New()
+	instance := &workflows.WorkflowInstance{
+		WorkflowDefinitionID: workflowDef.ID,
+		Name:                 "CanTransition Instance",
+		SystemSecurityPlanID: &sysID,
+	}
+	require.NoError(t, db.Create(instance).Error)
+
+	execution := &workflows.WorkflowExecution{
+		WorkflowInstanceID: instance.ID,
+		Status:             "in_progress",
+		TriggeredBy:        "manual",
+	}
+	require.NoError(t, db.Create(execution).Error)
+
+	stepDef := &workflows.WorkflowStepDefinition{
+		WorkflowDefinitionID: workflowDef.ID,
+		Name:                 "Step 1",
+		ResponsibleRole:      "engineer",
+	}
+	require.NoError(t, db.Create(stepDef).Error)
+
+	stepExec := &workflows.StepExecution{
+		WorkflowExecutionID:      execution.ID,
+		WorkflowStepDefinitionID: stepDef.ID,
+		Status:                   "pending",
+	}
+	require.NoError(t, db.Create(stepExec).Error)
+
+	assignedUserID := uuid.New().String()
+	require.NoError(t, db.Create(&workflows.RoleAssignment{
+		WorkflowInstanceID: instance.ID,
+		RoleName:           "engineer",
+		AssignedToType:     "user",
+		AssignedToID:       assignedUserID,
+		IsActive:           true,
+	}).Error)
+
+	makeRequest := func(stepID, userID, userType string) (*httptest.ResponseRecorder, error) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/workflows/step-executions/"+stepID+"/can-transition?user_id="+userID+"&user_type="+userType, nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues(stepID)
+		err := handler.CanTransition(c)
+		return rec, err
+	}
+
+	t.Run("UserType_user_assigned_returns_true", func(t *testing.T) {
+		rec, err := makeRequest(stepExec.ID.String(), assignedUserID, "user")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		data := resp["data"].(map[string]interface{})
+		assert.True(t, data["can-transition"].(bool))
+	})
+
+	t.Run("UserType_password_assigned_returns_true", func(t *testing.T) {
+		// Regression: password is the user's auth_method, not an assignment type.
+		// It must be normalized to "user" before querying role_assignments.
+		rec, err := makeRequest(stepExec.ID.String(), assignedUserID, "password")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		data := resp["data"].(map[string]interface{})
+		assert.True(t, data["can-transition"].(bool))
+		// user-type is normalized to "user" in the response after mapping from "password"
+		assert.Equal(t, "user", data["user-type"].(string))
+	})
+
+	t.Run("UserType_user_not_assigned_returns_false", func(t *testing.T) {
+		rec, err := makeRequest(stepExec.ID.String(), uuid.New().String(), "user")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		data := resp["data"].(map[string]interface{})
+		assert.False(t, data["can-transition"].(bool))
+	})
+
+	t.Run("MissingUserID_returns_400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/workflows/step-executions/"+stepExec.ID.String()+"/can-transition?user_type=user", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues(stepExec.ID.String())
+		err := handler.CanTransition(c)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("MissingUserType_returns_400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/workflows/step-executions/"+stepExec.ID.String()+"/can-transition?user_id="+assignedUserID, nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues(stepExec.ID.String())
+		err := handler.CanTransition(c)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("InvalidStepExecutionID_returns_400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/workflows/step-executions/not-a-uuid/can-transition?user_id="+assignedUserID+"&user_type=user", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues("not-a-uuid")
+		err := handler.CanTransition(c)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
 func TestStepExecutionHandler_Reassign(t *testing.T) {
 	handler, db := setupStepExecutionTestHandler(t)
 	e := echo.New()


### PR DESCRIPTION
## Summary

- The `can-transition` endpoint returned `false` for all password-authenticated users because the client was passing `user_type=password` (the user's `auth_method` value), which never matches any role assignment — assignments only use `user`, `email`, or `group`.
- Added normalization in the `CanTransition` handler to map `user_type=password` → `user` before querying, matching the behaviour the `Transition` handler already applies via JWT claims.

## What changed

**`internal/api/handler/workflows/step_execution.go`** — `CanTransition` handler now normalises `user_type=password` to `user` before passing to `CanUserTransitionStep`.

## Why

The `Transition` handler resolves user type from JWT claims (password-grant users with a `UserID` always resolve to assignment type `"user"`). The `CanTransition` handler had no such normalisation, so clients that mirrored the user's `auth_method` field as the query param ended up with a query that matched zero role assignments.

## Reviewer notes

- No schema or DB changes — the fix is purely in the handler layer.
- The `Transition` handler is unaffected (it derives type from claims, not query params).

🤖 Generated with [Claude Code](https://claude.com/claude-code)