### PR TITLE
fix: emit started evidence at trigger time

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -142,6 +142,7 @@ func RunServer(cmd *cobra.Command, args []string) {
 	workflowExecService := workflows.NewWorkflowExecutionService(db)
 	workflowInstService := workflows.NewWorkflowInstanceService(db)
 	stepExecService := workflows.NewStepExecutionService(db, nil)
+	workflowEvidenceIntegration := workflow.NewEvidenceIntegration(db, sugar)
 	workflowManager := workflow.NewManager(
 		workerService.GetClient(),
 		workflowExecService,
@@ -149,6 +150,7 @@ func RunServer(cmd *cobra.Command, args []string) {
 		stepExecService,
 		sugar,
 		workerService,
+		workflowEvidenceIntegration,
 	)
 
 	metrics := api.NewMetricsHandler(ctx, sugar)

--- a/internal/api/handler/workflows/workflow_execution_integration_test.go
+++ b/internal/api/handler/workflows/workflow_execution_integration_test.go
@@ -62,6 +62,7 @@ func setupExecutionTestHandler(t *testing.T) (*WorkflowExecutionHandler, *gorm.D
 		stepExecService,
 		logger,
 		nil,
+		nil,
 	)
 
 	handler := NewWorkflowExecutionHandler(logger, db, manager, assignmentService)

--- a/internal/service/relational/workflows/workflow_execution_service.go
+++ b/internal/service/relational/workflows/workflow_execution_service.go
@@ -179,14 +179,7 @@ func (s *WorkflowExecutionService) UpdateStatus(ctx context.Context, id *uuid.UU
 	}
 
 	if s.evidenceCreator != nil {
-		switch status {
-		case "in_progress":
-			if err := s.evidenceCreator.AddWorkflowExecutionEvidence(ctx, id, "started"); err != nil {
-				s.logger.Warnw("Failed to create workflow execution started evidence",
-					"workflow_execution_id", id,
-					"error", err)
-			}
-		case "completed":
+		if status == "completed" {
 			if err := s.evidenceCreator.AddWorkflowExecutionEvidence(ctx, id, "completed"); err != nil {
 				s.logger.Warnw("Failed to create workflow execution completed evidence",
 					"workflow_execution_id", id,

--- a/internal/service/worker/service.go
+++ b/internal/service/worker/service.go
@@ -188,6 +188,7 @@ func NewServiceWithDigest(
 		stepExecService,
 		logger,
 		enqueuerProxy,
+		evidenceIntegration,
 	)
 
 	// Determine grace period days for the workflow scheduler, with safe defaults.

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -40,6 +40,7 @@ func NewManager(
 	stepExecutionService StepExecutionServiceInterface,
 	logger *zap.SugaredLogger,
 	notificationEnqueuer NotificationEnqueuer,
+	evidenceCreator workflows.WorkflowExecutionEvidenceCreator,
 ) *Manager {
 	return &Manager{
 		riverClient:              riverClient,
@@ -48,6 +49,7 @@ func NewManager(
 		stepExecutionService:     stepExecutionService,
 		logger:                   logger,
 		notificationEnqueuer:     notificationEnqueuer,
+		evidenceCreator:          evidenceCreator,
 	}
 }
 

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -27,8 +27,8 @@ type Manager struct {
 	workflowExecutionService WorkflowExecutionServiceInterface
 	workflowInstanceService  WorkflowInstanceServiceInterface
 	stepExecutionService     StepExecutionServiceInterface
-	notificationEnqueuer     NotificationEnqueuer                        // Optional: for workflow notification emails
-	evidenceCreator          workflows.WorkflowExecutionEvidenceCreator  // Optional: for emitting started/completed evidence
+	notificationEnqueuer     NotificationEnqueuer                       // Optional: for workflow notification emails
+	evidenceCreator          workflows.WorkflowExecutionEvidenceCreator // Optional: for emitting started/completed evidence
 	logger                   *zap.SugaredLogger
 }
 

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -28,7 +28,7 @@ type Manager struct {
 	workflowInstanceService  WorkflowInstanceServiceInterface
 	stepExecutionService     StepExecutionServiceInterface
 	notificationEnqueuer     NotificationEnqueuer                       // Optional: for workflow notification emails
-	evidenceCreator          workflows.WorkflowExecutionEvidenceCreator // Optional: for emitting started/completed evidence
+	evidenceCreator          workflows.WorkflowExecutionEvidenceCreator // for emitting "started" evidence at trigger time
 	logger                   *zap.SugaredLogger
 }
 
@@ -53,7 +53,7 @@ func NewManager(
 	}
 }
 
-// SetEvidenceCreator sets the evidence creator for emitting execution-level evidence at trigger time.
+// SetEvidenceCreator sets the evidence creator for emitting "started" evidence at trigger time.
 func (m *Manager) SetEvidenceCreator(creator workflows.WorkflowExecutionEvidenceCreator) {
 	m.evidenceCreator = creator
 }

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -27,7 +27,8 @@ type Manager struct {
 	workflowExecutionService WorkflowExecutionServiceInterface
 	workflowInstanceService  WorkflowInstanceServiceInterface
 	stepExecutionService     StepExecutionServiceInterface
-	notificationEnqueuer     NotificationEnqueuer // Optional: for workflow notification emails
+	notificationEnqueuer     NotificationEnqueuer                        // Optional: for workflow notification emails
+	evidenceCreator          workflows.WorkflowExecutionEvidenceCreator  // Optional: for emitting started/completed evidence
 	logger                   *zap.SugaredLogger
 }
 
@@ -48,6 +49,11 @@ func NewManager(
 		logger:                   logger,
 		notificationEnqueuer:     notificationEnqueuer,
 	}
+}
+
+// SetEvidenceCreator sets the evidence creator for emitting execution-level evidence at trigger time.
+func (m *Manager) SetEvidenceCreator(creator workflows.WorkflowExecutionEvidenceCreator) {
+	m.evidenceCreator = creator
 }
 
 // StartWorkflowOptions contains options for starting a workflow execution
@@ -131,6 +137,15 @@ func (m *Manager) StartWorkflowExecution(ctx context.Context, workflowInstanceID
 		"execution_id", execution.ID,
 		"job_kind", JobTypeExecuteWorkflow,
 	)
+
+	if m.evidenceCreator != nil {
+		if err := m.evidenceCreator.AddWorkflowExecutionEvidence(ctx, execution.ID, "started"); err != nil {
+			m.logger.Warnw("Failed to emit started evidence at trigger time",
+				"execution_id", execution.ID,
+				"error", err,
+			)
+		}
+	}
 
 	return execution, nil
 }

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -18,6 +18,15 @@ import (
 	"go.uber.org/zap"
 )
 
+type MockWorkflowExecutionEvidenceCreator struct {
+	mock.Mock
+}
+
+func (m *MockWorkflowExecutionEvidenceCreator) AddWorkflowExecutionEvidence(ctx context.Context, workflowExecutionID *uuid.UUID, status string) error {
+	args := m.Called(ctx, workflowExecutionID, status)
+	return args.Error(0)
+}
+
 type MockRiverClient struct {
 	mock.Mock
 }
@@ -178,4 +187,63 @@ func TestManager_CancelExecution_CancelsOverdueSteps(t *testing.T) {
 	mockStepExecService.AssertNotCalled(t, "UpdateStatus", ctx, &completedStepID, StatusCancelled.String())
 	mockWorkflowExecService.AssertExpectations(t)
 	mockStepExecService.AssertExpectations(t)
+}
+
+// TestManager_StartWorkflowExecution_EmitsStartedEvidenceImmediately verifies that "started"
+// evidence is emitted at trigger time (when the execution is created as pending), not deferred
+// until the async transition to in_progress. Without this guarantee there is a timing window
+// where an execution exists in the system but has no evidence of having started.
+func TestManager_StartWorkflowExecution_EmitsStartedEvidenceImmediately(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop().Sugar()
+
+	instanceID := uuid.New()
+	executionID := uuid.New()
+
+	mockClient := &MockRiverClient{}
+	mockWorkflowExecService := &MockWorkflowExecutionService{}
+	mockWorkflowInstService := &MockWorkflowInstanceService{}
+	mockStepExecService := &MockStepExecutionService{}
+	mockEvidenceCreator := &MockWorkflowExecutionEvidenceCreator{}
+
+	manager := NewManager(
+		mockClient,
+		mockWorkflowExecService,
+		mockWorkflowInstService,
+		mockStepExecService,
+		logger,
+		nil,
+	)
+	manager.SetEvidenceCreator(mockEvidenceCreator)
+
+	mockWorkflowInstService.On("GetByID", &instanceID).Return(&workflows.WorkflowInstance{IsActive: true}, nil).Once()
+
+	// Simulate database assigning an ID on Create (normally done by UUIDModel.BeforeCreate GORM hook).
+	mockWorkflowExecService.On("Create", mock.AnythingOfType("*workflows.WorkflowExecution")).
+		Run(func(args mock.Arguments) {
+			exec := args.Get(0).(*workflows.WorkflowExecution)
+			id := executionID
+			exec.ID = &id
+		}).
+		Return(nil).Once()
+
+	mockClient.On("InsertMany", ctx, mock.Anything).Return([]*rivertype.JobInsertResult{}, nil).Once()
+
+	// The key assertion: evidence creator MUST be called at trigger time (while still pending),
+	// not deferred to the async in_progress transition.
+	mockEvidenceCreator.On("AddWorkflowExecutionEvidence", ctx, &executionID, "started").Return(nil).Once()
+
+	opts := StartWorkflowOptions{
+		TriggeredBy: workflows.TriggerManual.String(),
+	}
+
+	execution, err := manager.StartWorkflowExecution(ctx, &instanceID, opts)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	// This assertion fails because Manager currently does not call the evidence creator —
+	// "started" evidence is only emitted later when the River job transitions to in_progress.
+	mockEvidenceCreator.AssertExpectations(t)
+	mockWorkflowExecService.AssertExpectations(t)
+	mockWorkflowInstService.AssertExpectations(t)
 }

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -86,6 +86,7 @@ func TestManager_StartWorkflowExecution_UniqueViolationScheduledReturnsAlreadyEx
 		mockStepExecService,
 		logger,
 		nil,
+		nil,
 	)
 
 	mockWorkflowInstService.On("GetByID", &instanceID).Return(&workflows.WorkflowInstance{IsActive: true}, nil).Once()
@@ -122,6 +123,7 @@ func TestManager_StartWorkflowExecution_UniqueViolationManualDoesNotReturnAlread
 		mockWorkflowInstService,
 		mockStepExecService,
 		logger,
+		nil,
 		nil,
 	)
 
@@ -161,6 +163,7 @@ func TestManager_CancelExecution_CancelsOverdueSteps(t *testing.T) {
 		mockStepExecService,
 		logger,
 		nil,
+		nil,
 	)
 
 	mockWorkflowExecService.On("GetByID", &executionID).Return(&workflows.WorkflowExecution{
@@ -189,6 +192,56 @@ func TestManager_CancelExecution_CancelsOverdueSteps(t *testing.T) {
 	mockStepExecService.AssertExpectations(t)
 }
 
+// TestManager_StartWorkflowExecution_EmitsStartedEvidenceViaConstructor verifies that the
+// evidence creator passed to NewManager is used to emit "started" evidence at trigger time.
+// This is the regression test for the production wiring gap: neither cmd/run.go nor
+// worker/service.go ever calls SetEvidenceCreator, so evidence is silently dropped in production.
+// Fix: assign the evidenceCreator constructor arg to m.evidenceCreator inside NewManager.
+func TestManager_StartWorkflowExecution_EmitsStartedEvidenceViaConstructor(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop().Sugar()
+
+	instanceID := uuid.New()
+	executionID := uuid.New()
+
+	mockClient := &MockRiverClient{}
+	mockWorkflowExecService := &MockWorkflowExecutionService{}
+	mockWorkflowInstService := &MockWorkflowInstanceService{}
+	mockStepExecService := &MockStepExecutionService{}
+	mockEvidenceCreator := &MockWorkflowExecutionEvidenceCreator{}
+
+	manager := NewManager(
+		mockClient,
+		mockWorkflowExecService,
+		mockWorkflowInstService,
+		mockStepExecService,
+		logger,
+		nil,                 // notificationEnqueuer
+		mockEvidenceCreator, // evidenceCreator
+	)
+
+	mockWorkflowInstService.On("GetByID", &instanceID).Return(&workflows.WorkflowInstance{IsActive: true}, nil).Once()
+	mockWorkflowExecService.On("Create", mock.AnythingOfType("*workflows.WorkflowExecution")).
+		Run(func(args mock.Arguments) {
+			exec := args.Get(0).(*workflows.WorkflowExecution)
+			id := executionID
+			exec.ID = &id
+		}).
+		Return(nil).Once()
+	mockClient.On("InsertMany", ctx, mock.Anything).Return([]*rivertype.JobInsertResult{}, nil).Once()
+	mockEvidenceCreator.On("AddWorkflowExecutionEvidence", ctx, &executionID, "started").Return(nil).Once()
+
+	opts := StartWorkflowOptions{TriggeredBy: workflows.TriggerManual.String()}
+
+	execution, err := manager.StartWorkflowExecution(ctx, &instanceID, opts)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	mockEvidenceCreator.AssertExpectations(t)
+	mockWorkflowExecService.AssertExpectations(t)
+	mockWorkflowInstService.AssertExpectations(t)
+}
+
 // TestManager_StartWorkflowExecution_EmitsStartedEvidenceImmediately verifies that "started"
 // evidence is emitted at trigger time (when the execution is created as pending), not deferred
 // until the async transition to in_progress. Without this guarantee there is a timing window
@@ -212,6 +265,7 @@ func TestManager_StartWorkflowExecution_EmitsStartedEvidenceImmediately(t *testi
 		mockWorkflowInstService,
 		mockStepExecService,
 		logger,
+		nil,
 		nil,
 	)
 	manager.SetEvidenceCreator(mockEvidenceCreator)

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -229,7 +229,9 @@ func TestManager_StartWorkflowExecution_EmitsStartedEvidenceViaConstructor(t *te
 		}).
 		Return(nil).Once()
 	mockClient.On("InsertMany", ctx, mock.Anything).Return([]*rivertype.JobInsertResult{}, nil).Once()
-	mockEvidenceCreator.On("AddWorkflowExecutionEvidence", ctx, &executionID, "started").Return(nil).Once()
+	mockEvidenceCreator.On("AddWorkflowExecutionEvidence", ctx, mock.MatchedBy(func(id *uuid.UUID) bool {
+		return id != nil && *id == executionID
+	}), "started").Return(nil).Once()
 
 	opts := StartWorkflowOptions{TriggeredBy: workflows.TriggerManual.String()}
 
@@ -285,7 +287,9 @@ func TestManager_StartWorkflowExecution_EmitsStartedEvidenceImmediately(t *testi
 
 	// The key assertion: evidence creator MUST be called at trigger time (while still pending),
 	// not deferred to the async in_progress transition.
-	mockEvidenceCreator.On("AddWorkflowExecutionEvidence", ctx, &executionID, "started").Return(nil).Once()
+	mockEvidenceCreator.On("AddWorkflowExecutionEvidence", ctx, mock.MatchedBy(func(id *uuid.UUID) bool {
+		return id != nil && *id == executionID
+	}), "started").Return(nil).Once()
 
 	opts := StartWorkflowOptions{
 		TriggeredBy: workflows.TriggerManual.String(),
@@ -295,8 +299,6 @@ func TestManager_StartWorkflowExecution_EmitsStartedEvidenceImmediately(t *testi
 	require.NoError(t, err)
 	require.NotNil(t, execution)
 
-	// This assertion fails because Manager currently does not call the evidence creator —
-	// "started" evidence is only emitted later when the River job transitions to in_progress.
 	mockEvidenceCreator.AssertExpectations(t)
 	mockWorkflowExecService.AssertExpectations(t)
 	mockWorkflowInstService.AssertExpectations(t)


### PR DESCRIPTION
The Manager now calls AddWorkflowExecutionEvidence("started") immediately after a workflow execution is created and its River job is enqueued, while the execution is still in pending status. This closes the timing window where an execution existed in the system with no evidence of having started.

The corresponding call in WorkflowExecutionService.UpdateStatus (which fired on the pending→in_progress transition driven by the async River job) is removed to prevent duplicate evidence records. The "completed" evidence path in UpdateStatus is unchanged.