### PR TITLE
fix(BCH-1147): emit started evidence synchronously at trigger time

### DIFF
--- a/internal/service/relational/workflows/workflow_execution_service.go
+++ b/internal/service/relational/workflows/workflow_execution_service.go
@@ -186,12 +186,6 @@ func (s *WorkflowExecutionService) UpdateStatus(ctx context.Context, id *uuid.UU
 					"workflow_execution_id", id,
 					"error", err)
 			}
-		case "completed":
-			if err := s.evidenceCreator.AddWorkflowExecutionEvidence(ctx, id, "completed"); err != nil {
-				s.logger.Warnw("Failed to create workflow execution completed evidence",
-					"workflow_execution_id", id,
-					"error", err)
-			}
 		}
 	}
 

--- a/internal/service/worker/service.go
+++ b/internal/service/worker/service.go
@@ -189,6 +189,7 @@ func NewServiceWithDigest(
 		logger,
 		enqueuerProxy,
 	)
+	workflowManager.SetEvidenceCreator(evidenceIntegration)
 
 	// Determine grace period days for the workflow scheduler, with safe defaults.
 	gracePeriodDays := config.DefaultWorkflowConfig().GracePeriodDays

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -28,7 +28,14 @@ type Manager struct {
 	workflowInstanceService  WorkflowInstanceServiceInterface
 	stepExecutionService     StepExecutionServiceInterface
 	notificationEnqueuer     NotificationEnqueuer // Optional: for workflow notification emails
+	evidenceCreator          workflows.WorkflowExecutionEvidenceCreator
 	logger                   *zap.SugaredLogger
+}
+
+// SetEvidenceCreator wires an evidence creator so that "started" evidence is emitted
+// synchronously at trigger time rather than on the async in_progress transition.
+func (m *Manager) SetEvidenceCreator(ec workflows.WorkflowExecutionEvidenceCreator) {
+	m.evidenceCreator = ec
 }
 
 // NewManager creates a new workflow manager
@@ -131,6 +138,14 @@ func (m *Manager) StartWorkflowExecution(ctx context.Context, workflowInstanceID
 		"execution_id", execution.ID,
 		"job_kind", JobTypeExecuteWorkflow,
 	)
+
+	if m.evidenceCreator != nil {
+		if err := m.evidenceCreator.AddWorkflowExecutionEvidence(ctx, execution.ID, "started"); err != nil {
+			m.logger.Warnw("Failed to create workflow execution started evidence",
+				"execution_id", execution.ID,
+				"error", err)
+		}
+	}
 
 	return execution, nil
 }

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -132,6 +132,99 @@ func TestManager_StartWorkflowExecution_UniqueViolationManualDoesNotReturnAlread
 	assert.Contains(t, err.Error(), "failed to create workflow execution")
 }
 
+// MockEvidenceCreator is a mock for workflows.WorkflowExecutionEvidenceCreator
+type MockEvidenceCreator struct {
+	mock.Mock
+}
+
+func (m *MockEvidenceCreator) AddWorkflowExecutionEvidence(ctx context.Context, executionID *uuid.UUID, status string) error {
+	args := m.Called(ctx, executionID, status)
+	return args.Error(0)
+}
+
+func TestManager_StartWorkflowExecution_EmitsStartedEvidenceAtTriggerTime(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop().Sugar()
+
+	instanceID := uuid.New()
+	executionID := uuid.New()
+	mockClient := &MockRiverClient{}
+	mockWorkflowExecService := &MockWorkflowExecutionService{}
+	mockWorkflowInstService := &MockWorkflowInstanceService{}
+	mockStepExecService := &MockStepExecutionService{}
+	mockEvidence := &MockEvidenceCreator{}
+
+	manager := NewManager(
+		mockClient,
+		mockWorkflowExecService,
+		mockWorkflowInstService,
+		mockStepExecService,
+		logger,
+		nil,
+	)
+	manager.SetEvidenceCreator(mockEvidence)
+
+	mockWorkflowInstService.On("GetByID", &instanceID).Return(&workflows.WorkflowInstance{IsActive: true}, nil).Once()
+	mockWorkflowExecService.On("Create", mock.AnythingOfType("*workflows.WorkflowExecution")).
+		Run(func(args mock.Arguments) {
+			exec := args.Get(0).(*workflows.WorkflowExecution)
+			exec.ID = &executionID
+		}).
+		Return(nil).Once()
+	mockClient.On("InsertMany", ctx, mock.Anything).Return([]*rivertype.JobInsertResult{}, nil).Once()
+	mockEvidence.On("AddWorkflowExecutionEvidence", ctx, &executionID, "started").Return(nil).Once()
+
+	opts := StartWorkflowOptions{
+		TriggeredBy: workflows.TriggerManual.String(),
+	}
+
+	execution, err := manager.StartWorkflowExecution(ctx, &instanceID, opts)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	mockEvidence.AssertCalled(t, "AddWorkflowExecutionEvidence", ctx, &executionID, "started")
+	mockEvidence.AssertExpectations(t)
+	mockWorkflowExecService.AssertExpectations(t)
+}
+
+func TestManager_StartWorkflowExecution_NilEvidenceCreator_DoesNotPanic(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop().Sugar()
+
+	instanceID := uuid.New()
+	mockClient := &MockRiverClient{}
+	mockWorkflowExecService := &MockWorkflowExecutionService{}
+	mockWorkflowInstService := &MockWorkflowInstanceService{}
+	mockStepExecService := &MockStepExecutionService{}
+
+	manager := NewManager(
+		mockClient,
+		mockWorkflowExecService,
+		mockWorkflowInstService,
+		mockStepExecService,
+		logger,
+		nil,
+	)
+	// evidenceCreator intentionally not set (nil)
+
+	noopID := uuid.New()
+	mockWorkflowInstService.On("GetByID", &instanceID).Return(&workflows.WorkflowInstance{IsActive: true}, nil).Once()
+	mockWorkflowExecService.On("Create", mock.AnythingOfType("*workflows.WorkflowExecution")).
+		Run(func(args mock.Arguments) {
+			args.Get(0).(*workflows.WorkflowExecution).ID = &noopID
+		}).
+		Return(nil).Once()
+	mockClient.On("InsertMany", ctx, mock.Anything).Return([]*rivertype.JobInsertResult{}, nil).Once()
+
+	opts := StartWorkflowOptions{
+		TriggeredBy: workflows.TriggerManual.String(),
+	}
+
+	execution, err := manager.StartWorkflowExecution(ctx, &instanceID, opts)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+}
+
 func TestManager_CancelExecution_CancelsOverdueSteps(t *testing.T) {
 	ctx := context.Background()
 	logger := zap.NewNop().Sugar()


### PR DESCRIPTION
Add an optional evidence creator to the Manager so that "started" evidence is emitted immediately when StartWorkflowExecution is called, closing the timing gap that existed between execution creation (status=pending, startedAt populated) and the async in_progress transition where evidence was previously wired. Add tests capturing the bug and the nil-creator safety path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workflow execution state tracking to capture evidence when workflows start rather than on completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/api/pull/397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->