### PR TITLE
BCH-1148: Populate step_count in workflow definition list response

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -40166,6 +40166,10 @@ const docTemplate = `{
                     "description": "Basic Information",
                     "type": "string"
                 },
+                "step_count": {
+                    "description": "Computed fields (not persisted)",
+                    "type": "integer"
+                },
                 "steps": {
                     "description": "Relationships",
                     "type": "array",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -40167,8 +40167,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "step_count": {
-                    "description": "Computed fields (not persisted)",
-                    "type": "integer"
+                    "description": "Computed field (not persisted)",
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "steps": {
                     "description": "Relationships",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -40161,8 +40161,9 @@
                     "type": "string"
                 },
                 "step_count": {
-                    "description": "Computed fields (not persisted)",
-                    "type": "integer"
+                    "description": "Computed field (not persisted)",
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "steps": {
                     "description": "Relationships",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -40160,6 +40160,10 @@
                     "description": "Basic Information",
                     "type": "string"
                 },
+                "step_count": {
+                    "description": "Computed fields (not persisted)",
+                    "type": "integer"
+                },
                 "steps": {
                     "description": "Relationships",
                     "type": "array",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8880,7 +8880,8 @@ definitions:
         description: Basic Information
         type: string
       step_count:
-        description: Computed fields (not persisted)
+        description: Computed field (not persisted)
+        minimum: 0
         type: integer
       steps:
         description: Relationships

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8879,6 +8879,9 @@ definitions:
       name:
         description: Basic Information
         type: string
+      step_count:
+        description: Computed fields (not persisted)
+        type: integer
       steps:
         description: Relationships
         items:

--- a/internal/service/relational/workflows/workflow_definition.go
+++ b/internal/service/relational/workflows/workflow_definition.go
@@ -30,8 +30,8 @@ type WorkflowDefinition struct {
 	CreatedByID *uuid.UUID `gorm:"index" json:"created_by_id,omitempty"`
 	UpdatedByID *uuid.UUID `gorm:"index" json:"updated_by_id,omitempty"`
 
-	// Computed fields (not persisted)
-	StepCount int `gorm:"-" json:"step_count"`
+	// Computed field (not persisted)
+	StepCount int `gorm:"-" json:"step_count" validate:"min=0"`
 
 	// Relationships
 	Steps                []WorkflowStepDefinition `gorm:"foreignKey:WorkflowDefinitionID;constraint:OnDelete:CASCADE" json:"steps,omitempty"`

--- a/internal/service/relational/workflows/workflow_definition.go
+++ b/internal/service/relational/workflows/workflow_definition.go
@@ -30,6 +30,9 @@ type WorkflowDefinition struct {
 	CreatedByID *uuid.UUID `gorm:"index" json:"created_by_id,omitempty"`
 	UpdatedByID *uuid.UUID `gorm:"index" json:"updated_by_id,omitempty"`
 
+	// Computed fields (not persisted)
+	StepCount int `gorm:"-" json:"step_count"`
+
 	// Relationships
 	Steps                []WorkflowStepDefinition `gorm:"foreignKey:WorkflowDefinitionID;constraint:OnDelete:CASCADE" json:"steps,omitempty"`
 	ControlRelationships []ControlRelationship    `gorm:"foreignKey:WorkflowDefinitionID;constraint:OnDelete:CASCADE" json:"control_relationships,omitempty"`

--- a/internal/service/relational/workflows/workflow_definition_service.go
+++ b/internal/service/relational/workflows/workflow_definition_service.go
@@ -39,6 +39,7 @@ func (s *WorkflowDefinitionService) GetByID(id *uuid.UUID) (*WorkflowDefinition,
 	if err != nil {
 		return nil, err
 	}
+	definition.StepCount = len(definition.Steps)
 	return &definition, nil
 }
 
@@ -93,8 +94,15 @@ func (s *WorkflowDefinitionService) FindByName(name string) ([]WorkflowDefinitio
 		Preload("Steps").
 		Preload("ControlRelationships").
 		Find(&definitions).Error
+	if err != nil {
+		return nil, err
+	}
 
-	return definitions, err
+	for i := range definitions {
+		definitions[i].StepCount = len(definitions[i].Steps)
+	}
+
+	return definitions, nil
 }
 
 // GetWithInstances retrieves a workflow definition with all its instances
@@ -105,6 +113,7 @@ func (s *WorkflowDefinitionService) GetWithInstances(id *uuid.UUID) (*WorkflowDe
 	if err != nil {
 		return nil, err
 	}
+	definition.StepCount = len(definition.Steps)
 	return &definition, nil
 }
 

--- a/internal/service/relational/workflows/workflow_definition_service.go
+++ b/internal/service/relational/workflows/workflow_definition_service.go
@@ -63,6 +63,10 @@ func (s *WorkflowDefinitionService) GetAll(limit, offset int) ([]WorkflowDefinit
 		return nil, 0, err
 	}
 
+	for i := range definitions {
+		definitions[i].StepCount = len(definitions[i].Steps)
+	}
+
 	return definitions, total, nil
 }
 

--- a/internal/service/relational/workflows/workflow_definition_service_test.go
+++ b/internal/service/relational/workflows/workflow_definition_service_test.go
@@ -103,18 +103,27 @@ func TestWorkflowDefinitionService_GetAll_StepCount(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewWorkflowDefinitionService(db)
 
-	def := createTestWorkflowDefinition()
-	require.NoError(t, db.Create(def).Error)
+	defWithSteps := createTestWorkflowDefinition()
+	require.NoError(t, db.Create(defWithSteps).Error)
 
-	step1 := createTestWorkflowStepDefinition(def.ID)
-	step2 := createTestWorkflowStepDefinition(def.ID)
+	step1 := createTestWorkflowStepDefinition(defWithSteps.ID)
+	step2 := createTestWorkflowStepDefinition(defWithSteps.ID)
 	require.NoError(t, db.Create(step1).Error)
 	require.NoError(t, db.Create(step2).Error)
 
+	defWithoutSteps := createTestWorkflowDefinition()
+	require.NoError(t, db.Create(defWithoutSteps).Error)
+
 	retrieved, _, err := service.GetAll(10, 0)
 	require.NoError(t, err)
-	require.Len(t, retrieved, 1)
-	assert.Equal(t, 2, retrieved[0].StepCount)
+	require.Len(t, retrieved, 2)
+
+	counts := make(map[string]int)
+	for _, d := range retrieved {
+		counts[d.ID.String()] = d.StepCount
+	}
+	assert.Equal(t, 2, counts[defWithSteps.ID.String()])
+	assert.Equal(t, 0, counts[defWithoutSteps.ID.String()])
 }
 
 // TestWorkflowDefinitionService_Update tests the Update method

--- a/internal/service/relational/workflows/workflow_definition_service_test.go
+++ b/internal/service/relational/workflows/workflow_definition_service_test.go
@@ -98,6 +98,25 @@ func TestWorkflowDefinitionService_GetAll(t *testing.T) {
 	assert.Len(t, retrieved, 2)
 }
 
+// TestWorkflowDefinitionService_GetAll_StepCount tests that GetAll populates StepCount from associated steps
+func TestWorkflowDefinitionService_GetAll_StepCount(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewWorkflowDefinitionService(db)
+
+	def := createTestWorkflowDefinition()
+	require.NoError(t, db.Create(def).Error)
+
+	step1 := createTestWorkflowStepDefinition(def.ID)
+	step2 := createTestWorkflowStepDefinition(def.ID)
+	require.NoError(t, db.Create(step1).Error)
+	require.NoError(t, db.Create(step2).Error)
+
+	retrieved, _, err := service.GetAll(10, 0)
+	require.NoError(t, err)
+	require.Len(t, retrieved, 1)
+	assert.Equal(t, 2, retrieved[0].StepCount)
+}
+
 // TestWorkflowDefinitionService_Update tests the Update method
 func TestWorkflowDefinitionService_Update(t *testing.T) {
 	db := setupTestDB(t)


### PR DESCRIPTION
The API preloaded Steps but never exposed a step count field, causing the UI to always display 0 steps for workflow definitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow definitions now expose a computed, non-persisted step_count (integer, minimum 0), populated consistently across read operations.

* **Documentation**
  * API documentation updated to include the new step_count property in workflow definition schemas.

* **Tests**
  * Added unit test coverage verifying step_count population.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/api/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->