### PR TITLE
BCH-1153: Populate per-step metrics in workflow execution metrics resp

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -39302,13 +39302,15 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "completedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "durationMinutes": {
                     "type": "number"
                 },
                 "startedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "stepDefinitionId": {
                     "type": "string"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -39313,7 +39313,8 @@ const docTemplate = `{
                     "format": "date-time"
                 },
                 "stepDefinitionId": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 },
                 "stepName": {
                     "type": "string"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -39240,6 +39240,12 @@ const docTemplate = `{
                 "longestStepDuration": {
                     "$ref": "#/definitions/time.Duration"
                 },
+                "step_metrics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/workflow.StepMetric"
+                    }
+                },
                 "totalSteps": {
                     "type": "integer"
                 }
@@ -39289,6 +39295,26 @@ const docTemplate = `{
                 },
                 "totalSteps": {
                     "type": "integer"
+                }
+            }
+        },
+        "workflow.StepMetric": {
+            "type": "object",
+            "properties": {
+                "completed_at": {
+                    "type": "string"
+                },
+                "duration_minutes": {
+                    "type": "number"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "step_definition_id": {
+                    "type": "string"
+                },
+                "step_name": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -39234,13 +39234,13 @@ const docTemplate = `{
                 "duration": {
                     "$ref": "#/definitions/time.Duration"
                 },
-                "executionID": {
+                "executionId": {
                     "type": "string"
                 },
                 "longestStepDuration": {
                     "$ref": "#/definitions/time.Duration"
                 },
-                "step_metrics": {
+                "stepMetrics": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/workflow.StepMetric"
@@ -39301,19 +39301,19 @@ const docTemplate = `{
         "workflow.StepMetric": {
             "type": "object",
             "properties": {
-                "completed_at": {
+                "completedAt": {
                     "type": "string"
                 },
-                "duration_minutes": {
+                "durationMinutes": {
                     "type": "number"
                 },
-                "started_at": {
+                "startedAt": {
                     "type": "string"
                 },
-                "step_definition_id": {
+                "stepDefinitionId": {
                     "type": "string"
                 },
-                "step_name": {
+                "stepName": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -39234,6 +39234,12 @@
                 "longestStepDuration": {
                     "$ref": "#/definitions/time.Duration"
                 },
+                "step_metrics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/workflow.StepMetric"
+                    }
+                },
                 "totalSteps": {
                     "type": "integer"
                 }
@@ -39283,6 +39289,26 @@
                 },
                 "totalSteps": {
                     "type": "integer"
+                }
+            }
+        },
+        "workflow.StepMetric": {
+            "type": "object",
+            "properties": {
+                "completed_at": {
+                    "type": "string"
+                },
+                "duration_minutes": {
+                    "type": "number"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "step_definition_id": {
+                    "type": "string"
+                },
+                "step_name": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -39307,7 +39307,8 @@
                     "format": "date-time"
                 },
                 "stepDefinitionId": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid"
                 },
                 "stepName": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -39228,13 +39228,13 @@
                 "duration": {
                     "$ref": "#/definitions/time.Duration"
                 },
-                "executionID": {
+                "executionId": {
                     "type": "string"
                 },
                 "longestStepDuration": {
                     "$ref": "#/definitions/time.Duration"
                 },
-                "step_metrics": {
+                "stepMetrics": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/workflow.StepMetric"
@@ -39295,19 +39295,19 @@
         "workflow.StepMetric": {
             "type": "object",
             "properties": {
-                "completed_at": {
+                "completedAt": {
                     "type": "string"
                 },
-                "duration_minutes": {
+                "durationMinutes": {
                     "type": "number"
                 },
-                "started_at": {
+                "startedAt": {
                     "type": "string"
                 },
-                "step_definition_id": {
+                "stepDefinitionId": {
                     "type": "string"
                 },
-                "step_name": {
+                "stepName": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -39296,13 +39296,15 @@
             "type": "object",
             "properties": {
                 "completedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "durationMinutes": {
                     "type": "number"
                 },
                 "startedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "stepDefinitionId": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8314,6 +8314,7 @@ definitions:
         format: date-time
         type: string
       stepDefinitionId:
+        format: uuid
         type: string
       stepName:
         type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8261,11 +8261,11 @@ definitions:
         $ref: '#/definitions/time.Duration'
       duration:
         $ref: '#/definitions/time.Duration'
-      executionID:
+      executionId:
         type: string
       longestStepDuration:
         $ref: '#/definitions/time.Duration'
-      step_metrics:
+      stepMetrics:
         items:
           $ref: '#/definitions/workflow.StepMetric'
         type: array
@@ -8305,15 +8305,15 @@ definitions:
     type: object
   workflow.StepMetric:
     properties:
-      completed_at:
+      completedAt:
         type: string
-      duration_minutes:
+      durationMinutes:
         type: number
-      started_at:
+      startedAt:
         type: string
-      step_definition_id:
+      stepDefinitionId:
         type: string
-      step_name:
+      stepName:
         type: string
     type: object
   workflows.BulkReassignRoleResponse:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8306,10 +8306,12 @@ definitions:
   workflow.StepMetric:
     properties:
       completedAt:
+        format: date-time
         type: string
       durationMinutes:
         type: number
       startedAt:
+        format: date-time
         type: string
       stepDefinitionId:
         type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8265,6 +8265,10 @@ definitions:
         type: string
       longestStepDuration:
         $ref: '#/definitions/time.Duration'
+      step_metrics:
+        items:
+          $ref: '#/definitions/workflow.StepMetric'
+        type: array
       totalSteps:
         type: integer
     type: object
@@ -8298,6 +8302,19 @@ definitions:
         type: string
       totalSteps:
         type: integer
+    type: object
+  workflow.StepMetric:
+    properties:
+      completed_at:
+        type: string
+      duration_minutes:
+        type: number
+      started_at:
+        type: string
+      step_definition_id:
+        type: string
+      step_name:
+        type: string
     type: object
   workflows.BulkReassignRoleResponse:
     properties:

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -325,6 +325,7 @@ func (m *Manager) GetExecutionMetrics(ctx context.Context, executionID *uuid.UUI
 
 	// Calculate step metrics
 	var totalStepDuration time.Duration
+	var timedStepCount int
 	for _, step := range stepExecutions {
 		if step.WorkflowStepDefinitionID == nil {
 			continue
@@ -345,6 +346,7 @@ func (m *Manager) GetExecutionMetrics(ctx context.Context, executionID *uuid.UUI
 		if step.StartedAt != nil && step.CompletedAt != nil {
 			stepDuration := step.CompletedAt.Sub(*step.StartedAt)
 			totalStepDuration += stepDuration
+			timedStepCount++
 
 			if stepDuration > metrics.LongestStepDuration {
 				metrics.LongestStepDuration = stepDuration
@@ -357,8 +359,8 @@ func (m *Manager) GetExecutionMetrics(ctx context.Context, executionID *uuid.UUI
 		metrics.StepMetrics = append(metrics.StepMetrics, sm)
 	}
 
-	if len(stepExecutions) > 0 {
-		metrics.AverageStepDuration = totalStepDuration / time.Duration(len(stepExecutions))
+	if timedStepCount > 0 {
+		metrics.AverageStepDuration = totalStepDuration / time.Duration(timedStepCount)
 	}
 
 	return metrics, nil
@@ -384,7 +386,7 @@ type ExecutionStatus struct {
 
 // StepMetric holds per-step timing data for the metrics response
 type StepMetric struct {
-	StepDefinitionID uuid.UUID  `json:"stepDefinitionId"`
+	StepDefinitionID uuid.UUID  `json:"stepDefinitionId" swaggertype:"string" format:"uuid"`
 	StepName         string     `json:"stepName"`
 	StartedAt        *time.Time `json:"startedAt,omitempty" swaggertype:"string" format:"date-time"`
 	CompletedAt      *time.Time `json:"completedAt,omitempty" swaggertype:"string" format:"date-time"`

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -325,6 +325,13 @@ func (m *Manager) GetExecutionMetrics(ctx context.Context, executionID *uuid.UUI
 	// Calculate step metrics
 	var totalStepDuration time.Duration
 	for _, step := range stepExecutions {
+		sm := StepMetric{
+			StepDefinitionID: *step.WorkflowStepDefinitionID,
+			StepName:         step.WorkflowStepDefinition.Name,
+			StartedAt:        step.StartedAt,
+			CompletedAt:      step.CompletedAt,
+		}
+
 		if step.StartedAt != nil && step.CompletedAt != nil {
 			stepDuration := step.CompletedAt.Sub(*step.StartedAt)
 			totalStepDuration += stepDuration
@@ -332,7 +339,12 @@ func (m *Manager) GetExecutionMetrics(ctx context.Context, executionID *uuid.UUI
 			if stepDuration > metrics.LongestStepDuration {
 				metrics.LongestStepDuration = stepDuration
 			}
+
+			d := stepDuration.Minutes()
+			sm.DurationMinutes = &d
 		}
+
+		metrics.StepMetrics = append(metrics.StepMetrics, sm)
 	}
 
 	if len(stepExecutions) > 0 {
@@ -360,6 +372,15 @@ type ExecutionStatus struct {
 	FailureReason   string
 }
 
+// StepMetric holds per-step timing data for the metrics response
+type StepMetric struct {
+	StepDefinitionID uuid.UUID  `json:"step_definition_id"`
+	StepName         string     `json:"step_name"`
+	StartedAt        *time.Time `json:"started_at,omitempty"`
+	CompletedAt      *time.Time `json:"completed_at,omitempty"`
+	DurationMinutes  *float64   `json:"duration_minutes,omitempty"`
+}
+
 // ExecutionMetrics represents metrics for a workflow execution
 type ExecutionMetrics struct {
 	ExecutionID         uuid.UUID
@@ -367,4 +388,5 @@ type ExecutionMetrics struct {
 	Duration            time.Duration
 	AverageStepDuration time.Duration
 	LongestStepDuration time.Duration
+	StepMetrics         []StepMetric `json:"step_metrics"`
 }

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -309,6 +309,7 @@ func (m *Manager) GetExecutionMetrics(ctx context.Context, executionID *uuid.UUI
 	metrics := &ExecutionMetrics{
 		ExecutionID: *executionID,
 		TotalSteps:  len(stepExecutions),
+		StepMetrics: []StepMetric{},
 	}
 
 	// Calculate execution duration
@@ -374,19 +375,19 @@ type ExecutionStatus struct {
 
 // StepMetric holds per-step timing data for the metrics response
 type StepMetric struct {
-	StepDefinitionID uuid.UUID  `json:"step_definition_id"`
-	StepName         string     `json:"step_name"`
-	StartedAt        *time.Time `json:"started_at,omitempty"`
-	CompletedAt      *time.Time `json:"completed_at,omitempty"`
-	DurationMinutes  *float64   `json:"duration_minutes,omitempty"`
+	StepDefinitionID uuid.UUID  `json:"stepDefinitionId"`
+	StepName         string     `json:"stepName"`
+	StartedAt        *time.Time `json:"startedAt,omitempty"`
+	CompletedAt      *time.Time `json:"completedAt,omitempty"`
+	DurationMinutes  *float64   `json:"durationMinutes,omitempty"`
 }
 
 // ExecutionMetrics represents metrics for a workflow execution
 type ExecutionMetrics struct {
-	ExecutionID         uuid.UUID
-	TotalSteps          int
-	Duration            time.Duration
-	AverageStepDuration time.Duration
-	LongestStepDuration time.Duration
-	StepMetrics         []StepMetric `json:"step_metrics"`
+	ExecutionID         uuid.UUID     `json:"executionId"`
+	TotalSteps          int           `json:"totalSteps"`
+	Duration            time.Duration `json:"duration"`
+	AverageStepDuration time.Duration `json:"averageStepDuration"`
+	LongestStepDuration time.Duration `json:"longestStepDuration"`
+	StepMetrics         []StepMetric  `json:"stepMetrics"`
 }

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -326,9 +326,18 @@ func (m *Manager) GetExecutionMetrics(ctx context.Context, executionID *uuid.UUI
 	// Calculate step metrics
 	var totalStepDuration time.Duration
 	for _, step := range stepExecutions {
+		if step.WorkflowStepDefinitionID == nil {
+			continue
+		}
+
+		stepName := ""
+		if step.WorkflowStepDefinition != nil {
+			stepName = step.WorkflowStepDefinition.Name
+		}
+
 		sm := StepMetric{
 			StepDefinitionID: *step.WorkflowStepDefinitionID,
-			StepName:         step.WorkflowStepDefinition.Name,
+			StepName:         stepName,
 			StartedAt:        step.StartedAt,
 			CompletedAt:      step.CompletedAt,
 		}
@@ -377,8 +386,8 @@ type ExecutionStatus struct {
 type StepMetric struct {
 	StepDefinitionID uuid.UUID  `json:"stepDefinitionId"`
 	StepName         string     `json:"stepName"`
-	StartedAt        *time.Time `json:"startedAt,omitempty"`
-	CompletedAt      *time.Time `json:"completedAt,omitempty"`
+	StartedAt        *time.Time `json:"startedAt,omitempty" swaggertype:"string" format:"date-time"`
+	CompletedAt      *time.Time `json:"completedAt,omitempty" swaggertype:"string" format:"date-time"`
 	DurationMinutes  *float64   `json:"durationMinutes,omitempty"`
 }
 

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -179,3 +179,55 @@ func TestManager_CancelExecution_CancelsOverdueSteps(t *testing.T) {
 	mockWorkflowExecService.AssertExpectations(t)
 	mockStepExecService.AssertExpectations(t)
 }
+
+func TestManager_GetExecutionMetrics_PopulatesStepMetrics(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop().Sugar()
+
+	executionID := uuid.New()
+	stepDefID := uuid.New()
+	startedAt := time.Now().Add(-30 * time.Minute)
+	completedAt := time.Now()
+
+	mockClient := &MockRiverClient{}
+	mockWorkflowExecService := &MockWorkflowExecutionService{}
+	mockWorkflowInstService := &MockWorkflowInstanceService{}
+	mockStepExecService := &MockStepExecutionService{}
+
+	manager := NewManager(
+		mockClient,
+		mockWorkflowExecService,
+		mockWorkflowInstService,
+		mockStepExecService,
+		logger,
+		nil,
+	)
+
+	mockWorkflowExecService.On("GetByID", &executionID).Return(&workflows.WorkflowExecution{
+		UUIDModel:   relational.UUIDModel{ID: &executionID},
+		Status:      workflows.WorkflowStatusCompleted.String(),
+		StartedAt:   &startedAt,
+		CompletedAt: &completedAt,
+	}, nil).Once()
+
+	mockStepExecService.On("GetByWorkflowExecutionID", &executionID).Return([]workflows.StepExecution{
+		{
+			WorkflowStepDefinitionID: &stepDefID,
+			WorkflowStepDefinition: &workflows.WorkflowStepDefinition{
+				UUIDModel: relational.UUIDModel{ID: &stepDefID},
+				Name:      "Review Documentation",
+			},
+			StartedAt:   &startedAt,
+			CompletedAt: &completedAt,
+		},
+	}, nil).Once()
+
+	metrics, err := manager.GetExecutionMetrics(ctx, &executionID)
+	require.NoError(t, err)
+	require.Len(t, metrics.StepMetrics, 1)
+	assert.Equal(t, stepDefID, metrics.StepMetrics[0].StepDefinitionID)
+	assert.Equal(t, "Review Documentation", metrics.StepMetrics[0].StepName)
+	assert.NotNil(t, metrics.StepMetrics[0].DurationMinutes)
+	assert.Equal(t, startedAt, *metrics.StepMetrics[0].StartedAt)
+	assert.Equal(t, completedAt, *metrics.StepMetrics[0].CompletedAt)
+}

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -231,3 +231,49 @@ func TestManager_GetExecutionMetrics_PopulatesStepMetrics(t *testing.T) {
 	assert.Equal(t, startedAt, *metrics.StepMetrics[0].StartedAt)
 	assert.Equal(t, completedAt, *metrics.StepMetrics[0].CompletedAt)
 }
+
+func TestManager_GetExecutionMetrics_NilWorkflowStepDefinition(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop().Sugar()
+
+	executionID := uuid.New()
+	stepDefID := uuid.New()
+	startedAt := time.Now().Add(-30 * time.Minute)
+	completedAt := time.Now()
+
+	mockClient := &MockRiverClient{}
+	mockWorkflowExecService := &MockWorkflowExecutionService{}
+	mockWorkflowInstService := &MockWorkflowInstanceService{}
+	mockStepExecService := &MockStepExecutionService{}
+
+	manager := NewManager(
+		mockClient,
+		mockWorkflowExecService,
+		mockWorkflowInstService,
+		mockStepExecService,
+		logger,
+		nil,
+	)
+
+	mockWorkflowExecService.On("GetByID", &executionID).Return(&workflows.WorkflowExecution{
+		UUIDModel:   relational.UUIDModel{ID: &executionID},
+		Status:      workflows.WorkflowStatusCompleted.String(),
+		StartedAt:   &startedAt,
+		CompletedAt: &completedAt,
+	}, nil).Once()
+
+	mockStepExecService.On("GetByWorkflowExecutionID", &executionID).Return([]workflows.StepExecution{
+		{
+			WorkflowStepDefinitionID: &stepDefID,
+			WorkflowStepDefinition:   nil,
+			StartedAt:                &startedAt,
+			CompletedAt:              &completedAt,
+		},
+	}, nil).Once()
+
+	metrics, err := manager.GetExecutionMetrics(ctx, &executionID)
+	require.NoError(t, err)
+	require.Len(t, metrics.StepMetrics, 1)
+	assert.Equal(t, stepDefID, metrics.StepMetrics[0].StepDefinitionID)
+	assert.Equal(t, "", metrics.StepMetrics[0].StepName)
+}


### PR DESCRIPTION
The metrics endpoint only returned aggregate durations. The UI Step Performance table was always hidden because stepMetrics was never populated. Now each step execution contributes a StepMetric entry with its name, timestamps, and duration in minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow execution API now includes per-step metrics (started/completed timestamps, duration, step id/name).

* **Changes**
  * Renamed workflow execution identifier field to camelCase (executionId) for consistency.
  * Execution-level aggregations now consider only steps with both start and completion times.

* **Documentation**
  * OpenAPI/Swagger docs updated to reflect new stepMetrics and renamed field.

* **Tests**
  * Added unit tests for step metrics population and nil-step-definition handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/api/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->