### PR TITLE
fix: allow river to use polling only

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ func bindEnvironmentVariables() {
 	viper.MustBindEnv("digest_enabled")
 	viper.MustBindEnv("digest_schedule")
 	viper.MustBindEnv("worker_enabled")
+	viper.MustBindEnv("worker_use_polling")
 	viper.MustBindEnv("pprof_enabled")
 	viper.MustBindEnv("pprof_port")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -221,6 +221,9 @@ func NewConfig(logger *zap.SugaredLogger) *Config {
 	if viper.IsSet("worker_queue") {
 		workerConfig.Queue = viper.GetString("worker_queue")
 	}
+	if viper.IsSet("worker_use_polling") {
+		workerConfig.UsePolling = viper.GetBool("worker_use_polling")
+	}
 
 	pprofEnabled := viper.GetBool("pprof_enabled")
 	pprofPort := viper.GetString("pprof_port")

--- a/internal/config/worker.go
+++ b/internal/config/worker.go
@@ -5,6 +5,7 @@ package config
 //   - CCF_WORKER_ENABLED: Enable/disable workers (default: true)
 //   - CCF_WORKER_COUNT: Number of concurrent workers (default: 5)
 //   - CCF_WORKER_QUEUE: Queue name to process (default: "email")
+//   - CCF_WORKER_USE_POLLING: Use River polling instead of PostgreSQL LISTEN/NOTIFY (default: false)
 type WorkerConfig struct {
 	// Enabled determines if workers should be started
 	Enabled bool `mapstructure:"enabled"`
@@ -14,6 +15,9 @@ type WorkerConfig struct {
 
 	// Queue is the name of the queue to work on
 	Queue string `mapstructure:"queue"`
+
+	// UsePolling makes River poll for jobs instead of using PostgreSQL LISTEN/NOTIFY.
+	UsePolling bool `mapstructure:"use_polling"`
 
 	// RetryPolicy defines how jobs should be retried
 	RetryPolicy RetryPolicyConfig `mapstructure:"retry_policy"`
@@ -28,9 +32,10 @@ type RetryPolicyConfig struct {
 // DefaultWorkerConfig returns a default worker configuration
 func DefaultWorkerConfig() *WorkerConfig {
 	return &WorkerConfig{
-		Enabled: true,
-		Workers: 5,
-		Queue:   "email", // Default to email queue to match job configuration
+		Enabled:    true,
+		Workers:    5,
+		Queue:      "email", // Default to email queue to match job configuration
+		UsePolling: false,
 		RetryPolicy: RetryPolicyConfig{
 			MaxAttempts: 5,
 		},

--- a/internal/config/worker_test.go
+++ b/internal/config/worker_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultWorkerConfig_UsePollingDisabledByDefault(t *testing.T) {
+	cfg := DefaultWorkerConfig()
+
+	assert.False(t, cfg.UsePolling)
+}

--- a/internal/service/worker/service.go
+++ b/internal/service/worker/service.go
@@ -377,6 +377,7 @@ func (s *Service) Start(ctx context.Context) error {
 		"workers", s.config.Workers,
 		"default_email_queue", s.emailQueue(),
 		"slack_queue", s.slackQueue(),
+		"use_polling", s.config.UsePolling,
 	)
 
 	// Start the workers with the provided context (no dependency injection needed)
@@ -699,6 +700,7 @@ func periodicJobsFromConfig(cfg *config.Config, logger *zap.SugaredLogger) []*ri
 
 func buildRiverConfig(cfg *config.WorkerConfig, workers *river.Workers, periodicJobs []*river.PeriodicJob) river.Config {
 	return river.Config{
+		PollOnly: cfg.UsePolling,
 		Queues: map[string]river.QueueConfig{
 			"email": {
 				MaxWorkers: cfg.Workers,

--- a/internal/service/worker/service_test.go
+++ b/internal/service/worker/service_test.go
@@ -748,6 +748,23 @@ func TestBuildRiverConfig_IncludesSendSlackQueue(t *testing.T) {
 	assert.Equal(t, 7, sendSlackQueue.MaxWorkers)
 }
 
+func TestBuildRiverConfig_PollOnlyDisabledByDefault(t *testing.T) {
+	cfg := config.DefaultWorkerConfig()
+
+	riverConfig := buildRiverConfig(cfg, river.NewWorkers(), nil)
+
+	assert.False(t, riverConfig.PollOnly)
+}
+
+func TestBuildRiverConfig_PollOnlyCanBeEnabled(t *testing.T) {
+	cfg := config.DefaultWorkerConfig()
+	cfg.UsePolling = true
+
+	riverConfig := buildRiverConfig(cfg, river.NewWorkers(), nil)
+
+	assert.True(t, riverConfig.PollOnly)
+}
+
 func TestJobInsertOptionsForRiskDigest(t *testing.T) {
 	opts := JobInsertOptionsForRiskDigest(24 * time.Hour)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `CCF_WORKER_USE_POLLING` environment variable to enable polling-based worker behavior. Defaults to disabled, preserving existing PostgreSQL LISTEN/NOTIFY functionality.

* **Tests**
  * Added unit tests verifying polling configuration defaults and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/api/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->