### PR TITLE
BCH-1152: Enforce grace period hierarchy between definition, instance…

### DIFF
--- a/internal/api/handler/workflows/base.go
+++ b/internal/api/handler/workflows/base.go
@@ -103,6 +103,9 @@ func (b *BaseHandler) HandleServiceError(ctx echo.Context, err error, operation,
 	if err == gorm.ErrRecordNotFound || isNotFoundError(err) {
 		return ctx.JSON(http.StatusNotFound, api.NewError(err))
 	}
+	if isValidationError(err) {
+		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
+	}
 	b.sugar.Errorw("Failed to "+operation+" "+entityName, "error", err)
 	return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
 }
@@ -125,6 +128,13 @@ func (b *BaseHandler) RespondNoContent(ctx echo.Context) error {
 // isNotFoundError checks if an error is a "not found" error
 func isNotFoundError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "not found")
+}
+
+// isValidationError checks if an error is a user-visible validation error.
+// Validation errors are plain (no wrapped cause). DB/system errors always wrap an
+// underlying error with %w, so errors.Unwrap returns non-nil for those.
+func isValidationError(err error) bool {
+	return err != nil && errors.Unwrap(err) == nil && !isNotFoundError(err)
 }
 
 // GetActorFromClaims resolves the authenticated actor from JWT claims.

--- a/internal/api/handler/workflows/base.go
+++ b/internal/api/handler/workflows/base.go
@@ -8,6 +8,7 @@ import (
 	"github.com/compliance-framework/api/internal/api"
 	"github.com/compliance-framework/api/internal/authn"
 	"github.com/compliance-framework/api/internal/service/relational"
+	relworkflows "github.com/compliance-framework/api/internal/service/relational/workflows"
 	"github.com/compliance-framework/api/internal/service/sso"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -103,7 +104,8 @@ func (b *BaseHandler) HandleServiceError(ctx echo.Context, err error, operation,
 	if err == gorm.ErrRecordNotFound || isNotFoundError(err) {
 		return ctx.JSON(http.StatusNotFound, api.NewError(err))
 	}
-	if isValidationError(err) {
+	var ve *relworkflows.ValidationError
+	if errors.As(err, &ve) {
 		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
 	}
 	b.sugar.Errorw("Failed to "+operation+" "+entityName, "error", err)
@@ -128,13 +130,6 @@ func (b *BaseHandler) RespondNoContent(ctx echo.Context) error {
 // isNotFoundError checks if an error is a "not found" error
 func isNotFoundError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "not found")
-}
-
-// isValidationError checks if an error is a user-visible validation error.
-// Validation errors are plain (no wrapped cause). DB/system errors always wrap an
-// underlying error with %w, so errors.Unwrap returns non-nil for those.
-func isValidationError(err error) bool {
-	return err != nil && errors.Unwrap(err) == nil && !isNotFoundError(err)
 }
 
 // GetActorFromClaims resolves the authenticated actor from JWT claims.

--- a/internal/service/relational/workflows/base_service.go
+++ b/internal/service/relational/workflows/base_service.go
@@ -10,6 +10,22 @@ import (
 	"gorm.io/gorm"
 )
 
+// ValidationError marks a user-visible input validation failure.
+// Handlers map this to HTTP 400; anything else is treated as a system error (500).
+type ValidationError struct {
+	msg string
+}
+
+func (e *ValidationError) Error() string { return e.msg }
+
+func validationError(msg string) error {
+	return &ValidationError{msg: msg}
+}
+
+func validationErrorf(format string, args ...any) error {
+	return &ValidationError{msg: fmt.Sprintf(format, args...)}
+}
+
 // BaseService provides common CRUD operations for workflow entities
 type BaseService struct {
 	db *gorm.DB

--- a/internal/service/relational/workflows/workflow_instance_service.go
+++ b/internal/service/relational/workflows/workflow_instance_service.go
@@ -210,13 +210,29 @@ func (s *WorkflowInstanceService) ValidateInstance(instance *WorkflowInstance) e
 		return errors.New("grace period days must be non-negative")
 	}
 
-	return CombineErrors(
+	if err := CombineErrors(
 		ValidateStringRequired(instance.Name, "instance name"),
 		ValidateStringLength(instance.Name, "instance name", MaxNameLength),
 		ValidateUUIDRequired(instance.SystemSecurityPlanID, "system security plan ID"),
 		ValidateUUIDRequired(instance.WorkflowDefinitionID, "workflow definition ID"),
 		ValidateCadence(instance.Cadence),
-	)
+	); err != nil {
+		return err
+	}
+
+	// BCH-1152: instance grace period must be >= definition grace period when both are set.
+	if instance.GracePeriodDays != nil && instance.WorkflowDefinitionID != nil {
+		var defGrace *int
+		s.db.Model(&WorkflowDefinition{}).
+			Select("grace_period_days").
+			Where("id = ?", instance.WorkflowDefinitionID).
+			Scan(&defGrace)
+		if defGrace != nil && *instance.GracePeriodDays < *defGrace {
+			return errors.New("instance grace period days must be greater than or equal to the workflow definition grace period")
+		}
+	}
+
+	return nil
 }
 
 // CalculateNextSchedule calculates the next scheduled time based on cadence

--- a/internal/service/relational/workflows/workflow_instance_service.go
+++ b/internal/service/relational/workflows/workflow_instance_service.go
@@ -2,7 +2,6 @@ package workflows
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -205,10 +204,10 @@ func (s *WorkflowInstanceService) GetDueInstances(ctx context.Context) ([]Workfl
 // ValidateInstance validates a workflow instance
 func (s *WorkflowInstanceService) ValidateInstance(instance *WorkflowInstance) error {
 	if instance == nil {
-		return errors.New("workflow instance cannot be nil")
+		return validationError("workflow instance cannot be nil")
 	}
 	if instance.GracePeriodDays != nil && *instance.GracePeriodDays < 0 {
-		return errors.New("grace period days must be non-negative")
+		return validationError("grace period days must be non-negative")
 	}
 
 	if err := CombineErrors(
@@ -231,7 +230,7 @@ func (s *WorkflowInstanceService) ValidateInstance(instance *WorkflowInstance) e
 			return fmt.Errorf("failed to look up workflow definition grace period: %w", err)
 		}
 		if defGrace != nil && *instance.GracePeriodDays < *defGrace {
-			return errors.New("instance grace period days must be greater than or equal to the workflow definition grace period")
+			return validationError("instance grace period days must be greater than or equal to the workflow definition grace period")
 		}
 	}
 

--- a/internal/service/relational/workflows/workflow_instance_service.go
+++ b/internal/service/relational/workflows/workflow_instance_service.go
@@ -3,6 +3,7 @@ package workflows
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -223,10 +224,12 @@ func (s *WorkflowInstanceService) ValidateInstance(instance *WorkflowInstance) e
 	// BCH-1152: instance grace period must be >= definition grace period when both are set.
 	if instance.GracePeriodDays != nil && instance.WorkflowDefinitionID != nil {
 		var defGrace *int
-		s.db.Model(&WorkflowDefinition{}).
+		if err := s.db.Model(&WorkflowDefinition{}).
 			Select("grace_period_days").
 			Where("id = ?", instance.WorkflowDefinitionID).
-			Scan(&defGrace)
+			Scan(&defGrace).Error; err != nil {
+			return fmt.Errorf("failed to look up workflow definition grace period: %w", err)
+		}
 		if defGrace != nil && *instance.GracePeriodDays < *defGrace {
 			return errors.New("instance grace period days must be greater than or equal to the workflow definition grace period")
 		}

--- a/internal/service/relational/workflows/workflow_instance_service_test.go
+++ b/internal/service/relational/workflows/workflow_instance_service_test.go
@@ -781,3 +781,65 @@ func TestWorkflowInstanceService_Integration(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, reactivated.IsActive)
 }
+
+// TestWorkflowInstanceService_ValidateInstance_GraceHierarchy tests grace period hierarchy
+// validation between workflow instances and their parent definitions.
+// BCH-1152: instance.GracePeriodDays must be >= definition.GracePeriodDays when both are set.
+func TestWorkflowInstanceService_ValidateInstance_GraceHierarchy(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewWorkflowInstanceService(db)
+
+	defGrace := 10
+	def := createTestWorkflowDefinition()
+	def.GracePeriodDays = &defGrace
+	require.NoError(t, db.Create(def).Error)
+
+	t.Run("rejects instance grace period less than definition grace period", func(t *testing.T) {
+		instanceGrace := 5 // less than definition's 10
+		instance := createTestWorkflowInstance(def.ID)
+		instance.GracePeriodDays = &instanceGrace
+
+		err := service.ValidateInstance(instance)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "grace period")
+	})
+
+	t.Run("accepts instance grace period equal to definition grace period", func(t *testing.T) {
+		instanceGrace := 10
+		instance := createTestWorkflowInstance(def.ID)
+		instance.GracePeriodDays = &instanceGrace
+
+		err := service.ValidateInstance(instance)
+		assert.NoError(t, err)
+	})
+
+	t.Run("accepts instance grace period greater than definition grace period", func(t *testing.T) {
+		instanceGrace := 15
+		instance := createTestWorkflowInstance(def.ID)
+		instance.GracePeriodDays = &instanceGrace
+
+		err := service.ValidateInstance(instance)
+		assert.NoError(t, err)
+	})
+
+	t.Run("skips check when instance grace period is nil", func(t *testing.T) {
+		instance := createTestWorkflowInstance(def.ID)
+		instance.GracePeriodDays = nil
+
+		err := service.ValidateInstance(instance)
+		assert.NoError(t, err)
+	})
+
+	t.Run("skips check when definition grace period is nil", func(t *testing.T) {
+		defNoGrace := createTestWorkflowDefinition()
+		defNoGrace.GracePeriodDays = nil
+		require.NoError(t, db.Create(defNoGrace).Error)
+
+		instanceGrace := 5
+		instance := createTestWorkflowInstance(defNoGrace.ID)
+		instance.GracePeriodDays = &instanceGrace
+
+		err := service.ValidateInstance(instance)
+		assert.NoError(t, err)
+	})
+}

--- a/internal/service/relational/workflows/workflow_step_definition_service.go
+++ b/internal/service/relational/workflows/workflow_step_definition_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // WorkflowStepDefinitionService provides CRUD operations for WorkflowStepDefinition
@@ -24,9 +25,40 @@ func NewWorkflowStepDefinitionService(db *gorm.DB) *WorkflowStepDefinitionServic
 
 // Create creates a new workflow step definition
 func (s *WorkflowStepDefinitionService) Create(step *WorkflowStepDefinition) error {
+	// When a grace period is provided, lock the definition row so that concurrent
+	// creates against the same definition cannot both pass the sibling-sum check and
+	// collectively exceed the definition's grace period limit.
+	if step != nil && step.GracePeriodDays != nil && step.WorkflowDefinitionID != nil {
+		return s.db.Transaction(func(tx *gorm.DB) error {
+			if err := s.lockDefinition(tx, step.WorkflowDefinitionID); err != nil {
+				return err
+			}
+			return s.base.ValidateAndCreate(step, "workflow step definition", func() error {
+				return s.validateStep(tx, step, nil)
+			})
+		})
+	}
 	return s.base.ValidateAndCreate(step, "workflow step definition", func() error {
 		return s.ValidateStep(step)
 	})
+}
+
+// lockDefinition acquires a write lock on a workflow definition row to serialize
+// concurrent grace-period writes. On PostgreSQL this issues SELECT … FOR UPDATE;
+// on other databases (e.g. SQLite in tests) the clause is skipped and the transaction
+// alone provides the available isolation.
+func (s *WorkflowStepDefinitionService) lockDefinition(db *gorm.DB, id *uuid.UUID) error {
+	q := db.Model(&WorkflowDefinition{}).Select("id").Where("id = ?", id)
+	if db.Dialector.Name() == "postgres" {
+		q = q.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	if err := q.First(&WorkflowDefinition{}).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("workflow definition with id %s not found", id.String())
+		}
+		return fmt.Errorf("failed to lock workflow definition: %w", err)
+	}
+	return nil
 }
 
 // GetByID retrieves a workflow step definition by ID
@@ -64,6 +96,19 @@ func (s *WorkflowStepDefinitionService) GetByWorkflowDefinitionID(workflowDefID 
 // Update updates an existing workflow step definition
 func (s *WorkflowStepDefinitionService) Update(id *uuid.UUID, updates *WorkflowStepDefinition) error {
 	var existing WorkflowStepDefinition
+	// When grace period is being updated, lock the definition row to serialize concurrent
+	// updates so that the sibling-sum check cannot be defeated by concurrent writes.
+	if updates != nil && updates.GracePeriodDays != nil && updates.WorkflowDefinitionID != nil {
+		return s.db.Transaction(func(tx *gorm.DB) error {
+			if err := s.lockDefinition(tx, updates.WorkflowDefinitionID); err != nil {
+				return err
+			}
+			return s.base.ValidateAndUpdate(&existing, updates, id, "workflow step definition", func() error {
+				updates.ID = id
+				return s.validateStep(tx, updates, updates.ID)
+			})
+		})
+	}
 	return s.base.ValidateAndUpdate(&existing, updates, id, "workflow step definition", func() error {
 		updates.ID = id
 		return s.ValidateStepUpdate(updates)
@@ -168,44 +213,21 @@ func (s *WorkflowStepDefinitionService) GetDependentSteps(stepID *uuid.UUID) ([]
 
 // ValidateStep validates a workflow step definition for creation.
 func (s *WorkflowStepDefinitionService) ValidateStep(step *WorkflowStepDefinition) error {
-	return s.validateStep(step, nil)
+	return s.validateStep(s.db, step, nil)
 }
 
-// ValidateStepUpdate validates grace hierarchy for a partial update, excluding the
-// step's own current grace period from the sibling sum. Required-field checks are
-// omitted because updates may be partial.
+// ValidateStepUpdate validates a workflow step definition for an update, excluding
+// the step's own current grace period from the sibling sum. The update path receives
+// a fully populated step (the handler merges request fields onto the loaded row), so
+// the same invariants as creation are enforced.
 func (s *WorkflowStepDefinitionService) ValidateStepUpdate(step *WorkflowStepDefinition) error {
-	if step == nil || step.GracePeriodDays == nil || step.WorkflowDefinitionID == nil {
-		return nil
-	}
-	if *step.GracePeriodDays < 0 {
-		return errors.New("grace period days must be non-negative")
-	}
-	var defGrace *int
-	s.db.Model(&WorkflowDefinition{}).
-		Select("grace_period_days").
-		Where("id = ?", step.WorkflowDefinitionID).
-		Scan(&defGrace)
-	if defGrace == nil {
-		return nil
-	}
-	var siblingSum int
-	q := s.db.Model(&WorkflowStepDefinition{}).
-		Select("COALESCE(SUM(grace_period_days), 0)").
-		Where("workflow_definition_id = ? AND grace_period_days IS NOT NULL AND deleted_at IS NULL", step.WorkflowDefinitionID)
-	if step.ID != nil {
-		q = q.Where("id != ?", step.ID)
-	}
-	q.Scan(&siblingSum)
-	if siblingSum+*step.GracePeriodDays > *defGrace {
-		return fmt.Errorf("step grace period days would cause the total step grace period (%d) to exceed the workflow definition grace period (%d)", siblingSum+*step.GracePeriodDays, *defGrace)
-	}
-	return nil
+	return s.validateStep(s.db, step, step.ID)
 }
 
 // validateStep is the shared validation logic for create and update.
+// db is the connection (or transaction) to use for grace-period DB lookups.
 // excludeID, when non-nil, is excluded from the sibling grace period sum (update path).
-func (s *WorkflowStepDefinitionService) validateStep(step *WorkflowStepDefinition, excludeID *uuid.UUID) error {
+func (s *WorkflowStepDefinitionService) validateStep(db *gorm.DB, step *WorkflowStepDefinition, excludeID *uuid.UUID) error {
 	if step == nil {
 		return errors.New("workflow step definition cannot be nil")
 	}
@@ -236,19 +258,23 @@ func (s *WorkflowStepDefinitionService) validateStep(step *WorkflowStepDefinitio
 	// BCH-1152: sum of step grace periods must not exceed the definition grace period.
 	if step.GracePeriodDays != nil {
 		var defGrace *int
-		s.db.Model(&WorkflowDefinition{}).
+		if err := db.Model(&WorkflowDefinition{}).
 			Select("grace_period_days").
 			Where("id = ?", step.WorkflowDefinitionID).
-			Scan(&defGrace)
+			Scan(&defGrace).Error; err != nil {
+			return fmt.Errorf("failed to look up workflow definition grace period: %w", err)
+		}
 		if defGrace != nil {
 			var siblingSum int
-			q := s.db.Model(&WorkflowStepDefinition{}).
+			q := db.Model(&WorkflowStepDefinition{}).
 				Select("COALESCE(SUM(grace_period_days), 0)").
 				Where("workflow_definition_id = ? AND grace_period_days IS NOT NULL AND deleted_at IS NULL", step.WorkflowDefinitionID)
 			if excludeID != nil {
 				q = q.Where("id != ?", excludeID)
 			}
-			q.Scan(&siblingSum)
+			if err := q.Scan(&siblingSum).Error; err != nil {
+				return fmt.Errorf("failed to calculate sibling grace period sum: %w", err)
+			}
 			if siblingSum+*step.GracePeriodDays > *defGrace {
 				return fmt.Errorf("step grace period days would cause the total step grace period (%d) to exceed the workflow definition grace period (%d)", siblingSum+*step.GracePeriodDays, *defGrace)
 			}

--- a/internal/service/relational/workflows/workflow_step_definition_service.go
+++ b/internal/service/relational/workflows/workflow_step_definition_service.go
@@ -49,7 +49,7 @@ func (s *WorkflowStepDefinitionService) Create(step *WorkflowStepDefinition) err
 // alone provides the available isolation.
 func (s *WorkflowStepDefinitionService) lockDefinition(db *gorm.DB, id *uuid.UUID) error {
 	q := db.Model(&WorkflowDefinition{}).Select("id").Where("id = ?", id)
-	if db.Dialector.Name() == "postgres" {
+	if db.Name() == "postgres" {
 		q = q.Clauses(clause.Locking{Strength: "UPDATE"})
 	}
 	if err := q.First(&WorkflowDefinition{}).Error; err != nil {
@@ -127,7 +127,7 @@ func (s *WorkflowStepDefinitionService) Delete(id *uuid.UUID) error {
 	}
 
 	if dependentCount > 0 {
-		return fmt.Errorf("cannot delete step: %d other steps depend on it", dependentCount)
+		return validationErrorf("cannot delete step: %d other steps depend on it", dependentCount)
 	}
 
 	result := s.db.Delete(&WorkflowStepDefinition{}, id)
@@ -158,7 +158,7 @@ func (s *WorkflowStepDefinitionService) AddDependency(stepID, dependsOnStepID *u
 		First(&existing).Error
 
 	if err == nil {
-		return errors.New("dependency already exists")
+		return validationError("dependency already exists")
 	}
 
 	if !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -229,30 +229,30 @@ func (s *WorkflowStepDefinitionService) ValidateStepUpdate(step *WorkflowStepDef
 // excludeID, when non-nil, is excluded from the sibling grace period sum (update path).
 func (s *WorkflowStepDefinitionService) validateStep(db *gorm.DB, step *WorkflowStepDefinition, excludeID *uuid.UUID) error {
 	if step == nil {
-		return errors.New("workflow step definition cannot be nil")
+		return validationError("workflow step definition cannot be nil")
 	}
 
 	if step.Name == "" {
-		return errors.New("step name is required")
+		return validationError("step name is required")
 	}
 
 	if len(step.Name) > 255 {
-		return errors.New("step name cannot exceed 255 characters")
+		return validationError("step name cannot exceed 255 characters")
 	}
 
 	if step.ResponsibleRole == "" {
-		return errors.New("responsible role is required")
+		return validationError("responsible role is required")
 	}
 
 	if len(step.ResponsibleRole) > 255 {
-		return errors.New("responsible role cannot exceed 255 characters")
+		return validationError("responsible role cannot exceed 255 characters")
 	}
 
 	if step.WorkflowDefinitionID == nil {
-		return errors.New("workflow definition ID is required")
+		return validationError("workflow definition ID is required")
 	}
 	if step.GracePeriodDays != nil && *step.GracePeriodDays < 0 {
-		return errors.New("grace period days must be non-negative")
+		return validationError("grace period days must be non-negative")
 	}
 
 	// BCH-1152: sum of step grace periods must not exceed the definition grace period.
@@ -276,7 +276,7 @@ func (s *WorkflowStepDefinitionService) validateStep(db *gorm.DB, step *Workflow
 				return fmt.Errorf("failed to calculate sibling grace period sum: %w", err)
 			}
 			if siblingSum+*step.GracePeriodDays > *defGrace {
-				return fmt.Errorf("step grace period days would cause the total step grace period (%d) to exceed the workflow definition grace period (%d)", siblingSum+*step.GracePeriodDays, *defGrace)
+				return validationErrorf("step grace period days would cause the total step grace period (%d) to exceed the workflow definition grace period (%d)", siblingSum+*step.GracePeriodDays, *defGrace)
 			}
 		}
 	}

--- a/internal/service/relational/workflows/workflow_step_definition_service.go
+++ b/internal/service/relational/workflows/workflow_step_definition_service.go
@@ -33,7 +33,8 @@ func (s *WorkflowStepDefinitionService) Create(step *WorkflowStepDefinition) err
 			if err := s.lockDefinition(tx, step.WorkflowDefinitionID); err != nil {
 				return err
 			}
-			return s.base.ValidateAndCreate(step, "workflow step definition", func() error {
+			txBase := NewBaseService(tx)
+			return txBase.ValidateAndCreate(step, "workflow step definition", func() error {
 				return s.validateStep(tx, step, nil)
 			})
 		})
@@ -103,7 +104,8 @@ func (s *WorkflowStepDefinitionService) Update(id *uuid.UUID, updates *WorkflowS
 			if err := s.lockDefinition(tx, updates.WorkflowDefinitionID); err != nil {
 				return err
 			}
-			return s.base.ValidateAndUpdate(&existing, updates, id, "workflow step definition", func() error {
+			txBase := NewBaseService(tx)
+			return txBase.ValidateAndUpdate(&existing, updates, id, "workflow step definition", func() error {
 				updates.ID = id
 				return s.validateStep(tx, updates, updates.ID)
 			})

--- a/internal/service/relational/workflows/workflow_step_definition_service.go
+++ b/internal/service/relational/workflows/workflow_step_definition_service.go
@@ -64,7 +64,10 @@ func (s *WorkflowStepDefinitionService) GetByWorkflowDefinitionID(workflowDefID 
 // Update updates an existing workflow step definition
 func (s *WorkflowStepDefinitionService) Update(id *uuid.UUID, updates *WorkflowStepDefinition) error {
 	var existing WorkflowStepDefinition
-	return s.base.ValidateAndUpdate(&existing, updates, id, "workflow step definition", nil)
+	return s.base.ValidateAndUpdate(&existing, updates, id, "workflow step definition", func() error {
+		updates.ID = id
+		return s.ValidateStepUpdate(updates)
+	})
 }
 
 // Delete soft deletes a workflow step definition
@@ -163,8 +166,46 @@ func (s *WorkflowStepDefinitionService) GetDependentSteps(stepID *uuid.UUID) ([]
 	return dependents, err
 }
 
-// ValidateStep validates a workflow step definition
+// ValidateStep validates a workflow step definition for creation.
 func (s *WorkflowStepDefinitionService) ValidateStep(step *WorkflowStepDefinition) error {
+	return s.validateStep(step, nil)
+}
+
+// ValidateStepUpdate validates grace hierarchy for a partial update, excluding the
+// step's own current grace period from the sibling sum. Required-field checks are
+// omitted because updates may be partial.
+func (s *WorkflowStepDefinitionService) ValidateStepUpdate(step *WorkflowStepDefinition) error {
+	if step == nil || step.GracePeriodDays == nil || step.WorkflowDefinitionID == nil {
+		return nil
+	}
+	if *step.GracePeriodDays < 0 {
+		return errors.New("grace period days must be non-negative")
+	}
+	var defGrace *int
+	s.db.Model(&WorkflowDefinition{}).
+		Select("grace_period_days").
+		Where("id = ?", step.WorkflowDefinitionID).
+		Scan(&defGrace)
+	if defGrace == nil {
+		return nil
+	}
+	var siblingSum int
+	q := s.db.Model(&WorkflowStepDefinition{}).
+		Select("COALESCE(SUM(grace_period_days), 0)").
+		Where("workflow_definition_id = ? AND grace_period_days IS NOT NULL AND deleted_at IS NULL", step.WorkflowDefinitionID)
+	if step.ID != nil {
+		q = q.Where("id != ?", step.ID)
+	}
+	q.Scan(&siblingSum)
+	if siblingSum+*step.GracePeriodDays > *defGrace {
+		return fmt.Errorf("step grace period days would cause the total step grace period (%d) to exceed the workflow definition grace period (%d)", siblingSum+*step.GracePeriodDays, *defGrace)
+	}
+	return nil
+}
+
+// validateStep is the shared validation logic for create and update.
+// excludeID, when non-nil, is excluded from the sibling grace period sum (update path).
+func (s *WorkflowStepDefinitionService) validateStep(step *WorkflowStepDefinition, excludeID *uuid.UUID) error {
 	if step == nil {
 		return errors.New("workflow step definition cannot be nil")
 	}
@@ -190,6 +231,28 @@ func (s *WorkflowStepDefinitionService) ValidateStep(step *WorkflowStepDefinitio
 	}
 	if step.GracePeriodDays != nil && *step.GracePeriodDays < 0 {
 		return errors.New("grace period days must be non-negative")
+	}
+
+	// BCH-1152: sum of step grace periods must not exceed the definition grace period.
+	if step.GracePeriodDays != nil {
+		var defGrace *int
+		s.db.Model(&WorkflowDefinition{}).
+			Select("grace_period_days").
+			Where("id = ?", step.WorkflowDefinitionID).
+			Scan(&defGrace)
+		if defGrace != nil {
+			var siblingSum int
+			q := s.db.Model(&WorkflowStepDefinition{}).
+				Select("COALESCE(SUM(grace_period_days), 0)").
+				Where("workflow_definition_id = ? AND grace_period_days IS NOT NULL AND deleted_at IS NULL", step.WorkflowDefinitionID)
+			if excludeID != nil {
+				q = q.Where("id != ?", excludeID)
+			}
+			q.Scan(&siblingSum)
+			if siblingSum+*step.GracePeriodDays > *defGrace {
+				return fmt.Errorf("step grace period days would cause the total step grace period (%d) to exceed the workflow definition grace period (%d)", siblingSum+*step.GracePeriodDays, *defGrace)
+			}
+		}
 	}
 
 	return nil

--- a/internal/service/relational/workflows/workflow_step_definition_service_test.go
+++ b/internal/service/relational/workflows/workflow_step_definition_service_test.go
@@ -636,3 +636,87 @@ func TestWorkflowStepDefinitionService_Integration(t *testing.T) {
 	assert.Len(t, dependencies, 1)
 	assert.Equal(t, step1.ID, dependencies[0].ID)
 }
+
+// TestWorkflowStepDefinitionService_ValidateStep_GraceHierarchy tests that the sum of
+// step grace periods for a definition cannot exceed the definition's grace period.
+// BCH-1152: sum(step.GracePeriodDays) <= definition.GracePeriodDays when both are set.
+func TestWorkflowStepDefinitionService_ValidateStep_GraceHierarchy(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewWorkflowStepDefinitionService(db)
+
+	defGrace := 20
+	def := createTestWorkflowDefinition()
+	def.GracePeriodDays = &defGrace
+	require.NoError(t, db.Create(def).Error)
+
+	// Existing step with grace period 15 already persisted to the definition.
+	existingGrace := 15
+	existing := createTestWorkflowStepDefinition(def.ID)
+	existing.GracePeriodDays = &existingGrace
+	require.NoError(t, db.Create(existing).Error)
+
+	t.Run("rejects new step whose grace period would push sum over definition limit", func(t *testing.T) {
+		// existing=15, new=10 → sum=25 > 20
+		newGrace := 10
+		step := createTestWorkflowStepDefinition(def.ID)
+		step.GracePeriodDays = &newGrace
+
+		err := service.ValidateStep(step)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "grace period")
+	})
+
+	t.Run("accepts new step whose grace period keeps sum within definition limit", func(t *testing.T) {
+		// existing=15, new=5 → sum=20 == 20
+		newGrace := 5
+		step := createTestWorkflowStepDefinition(def.ID)
+		step.GracePeriodDays = &newGrace
+
+		err := service.ValidateStep(step)
+		assert.NoError(t, err)
+	})
+
+	t.Run("skips sum check when step grace period is nil", func(t *testing.T) {
+		step := createTestWorkflowStepDefinition(def.ID)
+		step.GracePeriodDays = nil
+
+		err := service.ValidateStep(step)
+		assert.NoError(t, err)
+	})
+
+	t.Run("skips sum check when definition grace period is nil", func(t *testing.T) {
+		defNoGrace := createTestWorkflowDefinition()
+		defNoGrace.GracePeriodDays = nil
+		require.NoError(t, db.Create(defNoGrace).Error)
+
+		newGrace := 100
+		step := createTestWorkflowStepDefinition(defNoGrace.ID)
+		step.GracePeriodDays = &newGrace
+
+		err := service.ValidateStep(step)
+		assert.NoError(t, err)
+	})
+
+	t.Run("update excludes the step being updated from the sum", func(t *testing.T) {
+		// existing step has grace=15; updating it to grace=20 → sum=20 == 20 (self excluded)
+		updatedGrace := 20
+		updated := createTestWorkflowStepDefinition(def.ID)
+		updated.ID = existing.ID // same step being updated
+		updated.GracePeriodDays = &updatedGrace
+
+		err := service.ValidateStepUpdate(updated)
+		assert.NoError(t, err)
+	})
+
+	t.Run("update rejects change that would push sum over limit", func(t *testing.T) {
+		// existing step has grace=15; updating it to grace=25 → sum=25 > 20
+		updatedGrace := 25
+		updated := createTestWorkflowStepDefinition(def.ID)
+		updated.ID = existing.ID
+		updated.GracePeriodDays = &updatedGrace
+
+		err := service.ValidateStepUpdate(updated)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "grace period")
+	})
+}

--- a/internal/service/relational/workflows/workflow_step_definition_service_test.go
+++ b/internal/service/relational/workflows/workflow_step_definition_service_test.go
@@ -168,12 +168,15 @@ func TestWorkflowStepDefinitionService_Update(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "updates cannot be nil")
 
-	// Test with non-existent ID
+	// Test with non-existent ID: the real update path always sends a fully populated
+	// struct (handler loads existing row then merges request fields), so ResponsibleRole
+	// is required here too — only the ID lookup produces "not found".
 	nonExistentID := uuid.New()
 	updatesWithNonExistentID := &WorkflowStepDefinition{
 		UUIDModel:            relational.UUIDModel{ID: &nonExistentID},
-		WorkflowDefinitionID: workflowDef.ID, // Include the workflow definition ID
+		WorkflowDefinitionID: workflowDef.ID,
 		Name:                 "Updated Step Definition",
+		ResponsibleRole:      "compliance_analyst",
 	}
 	err = service.Update(&nonExistentID, updatesWithNonExistentID)
 	assert.Error(t, err)


### PR DESCRIPTION
…, and step definitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instances now reject a grace period smaller than their parent workflow definition.
  * Step definitions enforce that the sum of step grace periods cannot exceed the parent workflow definition; create/update paths obtain a lock to validate against the parent when needed.

* **Behavior Changes**
  * Validation failures for user-visible input are returned as clear 400-level errors via a distinct validation error type.

* **Tests**
  * Added tests covering grace-period hierarchy rules for instances and step definitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/api/pull/404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->