### PR TITLE
fix: add error messages to provider status for misconfig

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -29671,6 +29671,9 @@ const docTemplate = `{
                 "enabled": {
                     "type": "boolean"
                 },
+                "error": {
+                    "type": "string"
+                },
                 "metadata": {
                     "type": "object",
                     "additionalProperties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -29665,6 +29665,9 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "error": {
+                    "type": "string"
+                },
                 "metadata": {
                     "type": "object",
                     "additionalProperties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1708,6 +1708,8 @@ definitions:
         type: string
       enabled:
         type: boolean
+      error:
+        type: string
       metadata:
         additionalProperties:
           type: string

--- a/internal/api/handler/notifications.go
+++ b/internal/api/handler/notifications.go
@@ -51,6 +51,7 @@ type availableNotificationProviderResponse struct {
 	DisplayName  string            `json:"displayName"`
 	Description  string            `json:"description"`
 	Enabled      bool              `json:"enabled"`
+	Error        string            `json:"error,omitempty"`
 	Metadata     map[string]string `json:"metadata,omitempty"`
 }
 
@@ -359,6 +360,7 @@ func (h *NotificationsHandler) ListNotificationProviders(ctx echo.Context) error
 			DisplayName:  provider.DisplayName,
 			Description:  provider.Description,
 			Enabled:      provider.Enabled,
+			Error:        provider.Error,
 			Metadata:     provider.Metadata,
 		})
 	}

--- a/internal/api/handler/notifications_test.go
+++ b/internal/api/handler/notifications_test.go
@@ -19,6 +19,26 @@ import (
 	"go.uber.org/zap"
 )
 
+type stubProviderCatalog struct {
+	providers []notification.ProviderMetadata
+}
+
+func (s stubProviderCatalog) Provider(providerID string) (notification.Provider, bool) {
+	return nil, false
+}
+
+func (s stubProviderCatalog) ProviderIDs() []string {
+	providerIDs := make([]string, 0, len(s.providers))
+	for _, provider := range s.providers {
+		providerIDs = append(providerIDs, provider.ProviderType)
+	}
+	return providerIDs
+}
+
+func (s stubProviderCatalog) Providers() []notification.ProviderMetadata {
+	return append([]notification.ProviderMetadata(nil), s.providers...)
+}
+
 type stubNotificationTestEnqueuer struct {
 	started bool
 	jobIDs  []int64
@@ -70,4 +90,38 @@ func TestSendTestNotificationReturnsJobIDs(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
 	require.Equal(t, []int64{42}, response.Data.JobIDs)
 	require.Equal(t, notification.DeliveryChannelEmail, response.Data.ProviderType)
+}
+
+func TestListNotificationProvidersReturnsProviderErrors(t *testing.T) {
+	e := echo.New()
+	handler := &NotificationsHandler{
+		sugar: zap.NewNop().Sugar(),
+		providers: stubProviderCatalog{providers: []notification.ProviderMetadata{
+			{
+				ProviderType: notification.DeliveryChannelSlack,
+				DisplayName:  "Slack",
+				Description:  "Configured Slack workspace",
+				Enabled:      true,
+				Error:        "invalid_auth",
+			},
+		}},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/notifications/providers", nil)
+	rec := httptest.NewRecorder()
+
+	err := handler.ListNotificationProviders(e.NewContext(req, rec))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var response GenericDataListResponse[availableNotificationProviderResponse]
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Len(t, response.Data, 1)
+	require.Equal(t, availableNotificationProviderResponse{
+		ProviderType: notification.DeliveryChannelSlack,
+		DisplayName:  "Slack",
+		Description:  "Configured Slack workspace",
+		Enabled:      true,
+		Error:        "invalid_auth",
+	}, response.Data[0])
 }

--- a/internal/service/notification/providers/slack/provider.go
+++ b/internal/service/notification/providers/slack/provider.go
@@ -90,6 +90,7 @@ type Provider struct {
 	workspaceConfigurationMu       sync.Mutex
 	workspaceConfigurationLoaded   bool
 	workspaceConfiguration         slacksvc.WorkspaceConfiguration
+	workspaceConfigurationErr      error
 }
 
 const (
@@ -163,7 +164,10 @@ func (p *Provider) ProviderMetadata() notification.ProviderMetadata {
 		Enabled:      p.enabled(),
 	}
 
-	configuration := p.workspaceConfigurationDetails()
+	configuration, err := p.workspaceConfigurationDetails()
+	if err != nil {
+		metadata.Error = err.Error()
+	}
 	if configuration.WorkspaceName != "" {
 		metadata.Description = fmt.Sprintf("Configured Slack workspace %s", configuration.WorkspaceName)
 	}
@@ -213,16 +217,16 @@ func (p *Provider) enabled() bool {
 	return sender != nil && sender.IsEnabled()
 }
 
-func (p *Provider) workspaceConfigurationDetails() slacksvc.WorkspaceConfiguration {
+func (p *Provider) workspaceConfigurationDetails() (slacksvc.WorkspaceConfiguration, error) {
 	if p == nil || p.workspaceConfigurationResolver == nil {
-		return slacksvc.WorkspaceConfiguration{}
+		return slacksvc.WorkspaceConfiguration{}, nil
 	}
 
 	p.workspaceConfigurationMu.Lock()
 	defer p.workspaceConfigurationMu.Unlock()
 
 	if p.workspaceConfigurationLoaded {
-		return p.workspaceConfiguration
+		return p.workspaceConfiguration, p.workspaceConfigurationErr
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -230,12 +234,14 @@ func (p *Provider) workspaceConfigurationDetails() slacksvc.WorkspaceConfigurati
 
 	configuration, err := p.workspaceConfigurationResolver(ctx)
 	if err != nil {
-		return p.workspaceConfiguration
+		p.workspaceConfigurationErr = err
+		return p.workspaceConfiguration, err
 	}
 
 	p.workspaceConfiguration = configuration
+	p.workspaceConfigurationErr = nil
 	p.workspaceConfigurationLoaded = true
-	return p.workspaceConfiguration
+	return p.workspaceConfiguration, nil
 }
 
 func (p *Provider) ResolveUserTarget(user notification.User) (notification.Target, bool, error) {

--- a/internal/service/notification/providers/slack/provider_test.go
+++ b/internal/service/notification/providers/slack/provider_test.go
@@ -88,10 +88,12 @@ func TestProviderMetadataRetriesWorkspaceDetailsAfterResolverError(t *testing.T)
 
 	firstMetadata := provider.ProviderMetadata()
 	assert.Equal(t, "Configured Slack workspace", firstMetadata.Description)
+	assert.Equal(t, "temporary slack failure", firstMetadata.Error)
 	assert.Empty(t, firstMetadata.Metadata)
 
 	secondMetadata := provider.ProviderMetadata()
 	assert.Equal(t, "Configured Slack workspace Recovered Workspace", secondMetadata.Description)
+	assert.Empty(t, secondMetadata.Error)
 	assert.Equal(t, "Recovered Workspace", secondMetadata.Metadata[MetadataKeyWorkspaceName])
 	assert.Equal(t, "T456", secondMetadata.Metadata[MetadataKeyTeamID])
 	assert.Equal(t, 2, attempts)

--- a/internal/service/notification/transport.go
+++ b/internal/service/notification/transport.go
@@ -28,6 +28,7 @@ type ProviderMetadata struct {
 	DisplayName  string
 	Description  string
 	Enabled      bool
+	Error        string
 	Metadata     map[string]string
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification providers now surface per-provider error messages in the provider list so users can see configuration failures (e.g., auth errors).
* **Documentation**
  * API schema and docs updated to include the new provider-level error field.
* **Tests**
  * Added tests to verify provider error reporting and resolver retry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/api/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->