### PR TITLE
fix: supports disable agent public endpoints via env vars

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ func setDefaultEnvironmentVariables() {
 	viper.SetDefault("digest_schedule", "@weekly")
 	viper.SetDefault("pprof_enabled", "false")
 	viper.SetDefault("pprof_port", ":6060")
+	viper.SetDefault("strict_disable_public_agent_endpoints", "false")
 }
 
 func bindEnvironmentVariables() {
@@ -60,6 +61,7 @@ func bindEnvironmentVariables() {
 	viper.MustBindEnv("worker_use_polling")
 	viper.MustBindEnv("pprof_enabled")
 	viper.MustBindEnv("pprof_port")
+	viper.MustBindEnv("strict_disable_public_agent_endpoints")
 }
 
 func init() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,6 +226,7 @@ func NewConfig(logger *zap.SugaredLogger) *Config {
 	}
 
 	pprofEnabled := viper.GetBool("pprof_enabled")
+	strictDisablePublicAgentEndpoints := viper.GetBool("strict_disable_public_agent_endpoints")
 	pprofPort := viper.GetString("pprof_port")
 	if pprofPort == "" {
 		pprofPort = "6060"
@@ -261,7 +262,7 @@ func NewConfig(logger *zap.SugaredLogger) *Config {
 		Poam:                              poamConfig,
 		PprofEnabled:                      pprofEnabled,
 		PprofPort:                         pprofPort,
-		StrictDisablePublicAgentEndpoints: viper.GetBool("strict_disable_public_agent_endpoints"),
+		StrictDisablePublicAgentEndpoints: strictDisablePublicAgentEndpoints,
 	}
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration setting to control public agent endpoints via the `CCF_STRICT_DISABLE_PUBLIC_AGENT_ENDPOINTS` environment variable (default: disabled).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->