### PR TITLE
fix: component suggestion bugs

### DIFF
--- a/internal/api/handler/filter.go
+++ b/internal/api/handler/filter.go
@@ -115,7 +115,7 @@ func (h *FilterHandler) List(ctx echo.Context) error {
 	if controlID != "" && componentID == "" {
 		query = query.
 			Joins("JOIN filter_controls ON filter_controls.filter_id = filters.id").
-			Joins("JOIN controls ON controls.catalog_id = filter_controls.control_catalog_id::uuid AND controls.id = filter_controls.control_id").
+			Joins("JOIN controls ON controls.catalog_id = filter_controls.control_catalog_id AND controls.id = filter_controls.control_id").
 			Where("controls.id = ?", controlID).
 			Distinct()
 	}

--- a/internal/api/handler/oscal/system_security_plan_suggestions_integration_test.go
+++ b/internal/api/handler/oscal/system_security_plan_suggestions_integration_test.go
@@ -147,8 +147,51 @@ func (suite *SystemComponentSuggestionsIntegrationSuite) buildSSP(controlID stri
 // It seeds the data directly into the DB, mirroring what SubjectTemplateService does in production.
 // Returns the DefinedComponent UUID and ComponentDefinition UUID.
 func (suite *SystemComponentSuggestionsIntegrationSuite) buildFilterAndEvidence(controlID string) (string, string) {
+	return suite.buildFilterAndEvidenceInCatalog(uuid.Nil, controlID, "test-"+controlID)
+}
+
+// buildCatalogWithControl creates a Catalog and a Control row with the given control ID,
+// returning the catalog ID. Used to seed the same control ID in multiple catalogs.
+func (suite *SystemComponentSuggestionsIntegrationSuite) buildCatalogWithControl(controlID string) uuid.UUID {
+	catalog := relational.Catalog{}
+	suite.Require().NoError(suite.DB.Create(&catalog).Error)
+	control := relational.Control{
+		CatalogID: *catalog.ID,
+		ID:        controlID,
+		Title:     "Control " + controlID,
+	}
+	suite.Require().NoError(suite.DB.Create(&control).Error)
+	return *catalog.ID
+}
+
+// linkSSPToProfileWithControls creates a Profile, binds it to the SSP via ssp_profiles,
+// and registers each (catalogID, controlID) pair in profile_controls so the SSP's control
+// resolution is scoped to that catalog. Returns the profile ID.
+func (suite *SystemComponentSuggestionsIntegrationSuite) linkSSPToProfileWithControls(sspID string, catalogID uuid.UUID, controlIDs ...string) uuid.UUID {
+	profileID := uuid.New()
+	profile := relational.Profile{UUIDModel: relational.UUIDModel{ID: &profileID}}
+	suite.Require().NoError(suite.DB.Create(&profile).Error)
+
+	suite.Require().NoError(suite.DB.Exec(
+		`INSERT INTO ssp_profiles (system_security_plan_id, profile_id) VALUES (?, ?)`,
+		sspID, profileID,
+	).Error)
+
+	for _, controlID := range controlIDs {
+		suite.Require().NoError(suite.DB.Exec(
+			`INSERT INTO profile_controls (profile_id, control_catalog_id, control_id) VALUES (?, ?, ?)`,
+			profileID, catalogID, controlID,
+		).Error)
+	}
+
+	return profileID
+}
+
+// buildFilterAndEvidenceInCatalog is buildFilterAndEvidence with an explicit catalog scope
+// on the filter_controls row and a caller-chosen label value, so the same control ID can be
+// seeded in different catalogs with distinguishable components.
+func (suite *SystemComponentSuggestionsIntegrationSuite) buildFilterAndEvidenceInCatalog(catalogID uuid.UUID, controlID, labelValue string) (string, string) {
 	labelKey := "plugin"
-	labelValue := "test-" + controlID
 
 	// 1. Create a Filter with a label condition matching labelKey=labelValue
 	lf := labelfilter.Filter{
@@ -166,10 +209,10 @@ func (suite *SystemComponentSuggestionsIntegrationSuite) buildFilterAndEvidence(
 	}
 	suite.Require().NoError(suite.DB.Create(&filter).Error)
 
-	// 2. Link the Filter to the controlID via the filter_controls join table
+	// 2. Link the Filter to the (catalogID, controlID) pair via the filter_controls join table
 	suite.Require().NoError(suite.DB.Exec(
 		`INSERT INTO filter_controls (filter_id, control_catalog_id, control_id) VALUES (?, ?, ?)`,
-		filter.ID, uuid.Nil, controlID,
+		filter.ID, catalogID, controlID,
 	).Error)
 
 	// 3. Create an Evidence record with matching labels
@@ -199,6 +242,104 @@ func (suite *SystemComponentSuggestionsIntegrationSuite) buildFilterAndEvidence(
 	suite.Require().NoError(suite.DB.Create(&dc).Error)
 
 	// 5. Store label match scoped to the DefinedComponent.
+	suite.Require().NoError(suite.DB.Exec(
+		`INSERT INTO component_definition_labels (defined_component_id, component_definition_id, key, value) VALUES (?, ?, ?, ?)`,
+		dc.ID, compDef.ID, labelKey, labelValue,
+	).Error)
+
+	return dc.ID.String(), compDef.ID.String()
+}
+
+// buildSSPWithTwoImplReqs creates and POSTs a minimal SSP with two ImplementedRequirements,
+// one per given control ID. Returns the SSP UUID and both ImplementedRequirement UUIDs.
+func (suite *SystemComponentSuggestionsIntegrationSuite) buildSSPWithTwoImplReqs(controlA, controlB string) (sspID, implReqA, implReqB string) {
+	sspID = uuid.New().String()
+	implReqA = uuid.New().String()
+	implReqB = uuid.New().String()
+	now := time.Now()
+
+	ssp := &oscalTypes_1_1_3.SystemSecurityPlan{
+		UUID: sspID,
+		Metadata: oscalTypes_1_1_3.Metadata{
+			Title: "Two-Req SSP", Version: "1.0", OscalVersion: "1.1.3", LastModified: now,
+		},
+		ImportProfile: oscalTypes_1_1_3.ImportProfile{Href: "https://example.com/profile"},
+		SystemCharacteristics: oscalTypes_1_1_3.SystemCharacteristics{
+			SystemName: "Two-Req System", Description: "desc", SecuritySensitivityLevel: "moderate",
+			SystemIds:         []oscalTypes_1_1_3.SystemId{{IdentifierType: "https://ietf.org/rfc/rfc4122", ID: uuid.New().String()}},
+			Status:            oscalTypes_1_1_3.Status{State: "operational"},
+			SystemInformation: oscalTypes_1_1_3.SystemInformation{InformationTypes: []oscalTypes_1_1_3.InformationType{{UUID: uuid.New().String(), Title: "t", Description: "d"}}},
+		},
+		SystemImplementation: oscalTypes_1_1_3.SystemImplementation{
+			Users:      []oscalTypes_1_1_3.SystemUser{{UUID: uuid.New().String(), Title: "Admin"}},
+			Components: []oscalTypes_1_1_3.SystemComponent{{UUID: uuid.New().String(), Type: "software", Title: "Seed", Description: "d", Status: oscalTypes_1_1_3.SystemComponentStatus{State: "operational"}}},
+		},
+		ControlImplementation: oscalTypes_1_1_3.ControlImplementation{
+			Description: "two-req ctrl",
+			ImplementedRequirements: []oscalTypes_1_1_3.ImplementedRequirement{
+				{UUID: implReqA, ControlId: controlA},
+				{UUID: implReqB, ControlId: controlB},
+			},
+		},
+	}
+
+	rec, req := suite.req(http.MethodPost, "/api/oscal/system-security-plans", ssp)
+	suite.server.E().ServeHTTP(rec, req)
+	suite.Require().Equal(http.StatusCreated, rec.Code, "failed to create SSP: %s", rec.Body.String())
+	return
+}
+
+// buildSharedFilterAndEvidence creates ONE DefinedComponent whose evidence matches ALL of the
+// given control IDs: one Filter per control, all selecting the same labelled Evidence.
+// Returns the DefinedComponent UUID and ComponentDefinition UUID.
+func (suite *SystemComponentSuggestionsIntegrationSuite) buildSharedFilterAndEvidence(controlIDs ...string) (string, string) {
+	labelKey := "plugin"
+	labelValue := "shared-" + uuid.New().String()
+
+	lf := labelfilter.Filter{
+		Scope: &labelfilter.Scope{
+			Condition: &labelfilter.Condition{
+				Label:    labelKey,
+				Operator: "=",
+				Value:    labelValue,
+			},
+		},
+	}
+	for _, controlID := range controlIDs {
+		filter := relational.Filter{
+			Name:   "filter-for-" + controlID,
+			Filter: datatypes.NewJSONType(lf),
+		}
+		suite.Require().NoError(suite.DB.Create(&filter).Error)
+		suite.Require().NoError(suite.DB.Exec(
+			`INSERT INTO filter_controls (filter_id, control_catalog_id, control_id) VALUES (?, ?, ?)`,
+			filter.ID, uuid.Nil, controlID,
+		).Error)
+	}
+
+	now := time.Now()
+	evidence := relational.Evidence{
+		UUID:        uuid.New(),
+		Title:       "shared evidence",
+		Description: "evidence matching multiple controls",
+		Start:       now,
+		End:         now,
+	}
+	suite.Require().NoError(suite.DB.Create(&evidence).Error)
+	suite.Require().NoError(suite.DB.Exec(
+		`INSERT INTO evidence_labels (evidence_id, labels_name, labels_value) VALUES (?, ?, ?)`,
+		evidence.ID, labelKey, labelValue,
+	).Error)
+
+	compDef := relational.ComponentDefinition{}
+	suite.Require().NoError(suite.DB.Create(&compDef).Error)
+	dc := relational.DefinedComponent{
+		Type:                  "software",
+		Title:                 "Shared Suggested Component",
+		Description:           "A component relevant to multiple requirements",
+		ComponentDefinitionID: compDef.ID,
+	}
+	suite.Require().NoError(suite.DB.Create(&dc).Error)
 	suite.Require().NoError(suite.DB.Exec(
 		`INSERT INTO component_definition_labels (defined_component_id, component_definition_id, key, value) VALUES (?, ?, ?, ?)`,
 		dc.ID, compDef.ID, labelKey, labelValue,
@@ -386,6 +527,116 @@ func (suite *SystemComponentSuggestionsIntegrationSuite) TestSuggestComponents_N
 	suite.Empty(resp.Data)
 }
 
+// TestSuggestComponents_AmbiguousControlID_ScopedToLinkedCatalog guards catalog-scoped
+// control resolution: the same control ID exists in two catalogs, each with its own
+// Filter/Evidence/DefinedComponent chain, and the SSP is linked (via ssp_profiles →
+// profile_controls) to a profile importing the control from only one catalog. Only the
+// linked catalog's component may be suggested.
+func (suite *SystemComponentSuggestionsIntegrationSuite) TestSuggestComponents_AmbiguousControlID_ScopedToLinkedCatalog() {
+	const controlID = "ac-1"
+	catalogA := suite.buildCatalogWithControl(controlID)
+	catalogB := suite.buildCatalogWithControl(controlID)
+
+	dcA, _ := suite.buildFilterAndEvidenceInCatalog(catalogA, controlID, "catalog-a-component")
+	suite.buildFilterAndEvidenceInCatalog(catalogB, controlID, "catalog-b-component")
+
+	sspID, implReqID := suite.buildSSP(controlID)
+	suite.linkSSPToProfileWithControls(sspID, catalogA, controlID)
+
+	rec, req := suite.req(http.MethodPost,
+		fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/suggest-components", sspID, implReqID),
+		nil)
+	suite.server.E().ServeHTTP(rec, req)
+	suite.Equal(http.StatusOK, rec.Code, rec.Body.String())
+
+	var resp handler.GenericDataListResponse[relational.SystemComponentSuggestion]
+	suite.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &resp))
+	suite.Require().Len(resp.Data, 1, "only the component from the SSP's linked catalog should be suggested")
+	suite.Equal(dcA, resp.Data[0].DefinedComponentID.String())
+}
+
+// TestSuggestComponents_AmbiguousControlID_NoLinkedProfile_GlobalFallback documents the
+// fallback: an SSP without linked profiles has no catalog scope, so the same control ID in
+// two catalogs resolves against both.
+func (suite *SystemComponentSuggestionsIntegrationSuite) TestSuggestComponents_AmbiguousControlID_NoLinkedProfile_GlobalFallback() {
+	const controlID = "ac-1"
+	catalogA := suite.buildCatalogWithControl(controlID)
+	catalogB := suite.buildCatalogWithControl(controlID)
+
+	dcA, _ := suite.buildFilterAndEvidenceInCatalog(catalogA, controlID, "catalog-a-component")
+	dcB, _ := suite.buildFilterAndEvidenceInCatalog(catalogB, controlID, "catalog-b-component")
+
+	sspID, implReqID := suite.buildSSP(controlID)
+
+	rec, req := suite.req(http.MethodPost,
+		fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/suggest-components", sspID, implReqID),
+		nil)
+	suite.server.E().ServeHTTP(rec, req)
+	suite.Equal(http.StatusOK, rec.Code, rec.Body.String())
+
+	var resp handler.GenericDataListResponse[relational.SystemComponentSuggestion]
+	suite.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &resp))
+	suite.Require().Len(resp.Data, 2, "without linked profiles both catalogs' components are suggested")
+	got := []string{resp.Data[0].DefinedComponentID.String(), resp.Data[1].DefinedComponentID.String()}
+	suite.Contains(got, dcA)
+	suite.Contains(got, dcB)
+}
+
+// TestSuggestComponents_LinkedProfileWithoutControl_NoSuggestions guards strict scoping:
+// once the SSP is linked to profiles, a control absent from all of them resolves to nothing,
+// even if a global filter for that control ID exists in another catalog.
+func (suite *SystemComponentSuggestionsIntegrationSuite) TestSuggestComponents_LinkedProfileWithoutControl_NoSuggestions() {
+	const controlID = "ac-1"
+	catalogA := suite.buildCatalogWithControl("si-4")
+	catalogB := suite.buildCatalogWithControl(controlID)
+
+	suite.buildFilterAndEvidenceInCatalog(catalogB, controlID, "catalog-b-component")
+
+	sspID, implReqID := suite.buildSSP(controlID)
+	// The linked profile imports a different control from catalog A; "ac-1" is out of scope.
+	suite.linkSSPToProfileWithControls(sspID, catalogA, "si-4")
+
+	rec, req := suite.req(http.MethodPost,
+		fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/suggest-components", sspID, implReqID),
+		nil)
+	suite.server.E().ServeHTTP(rec, req)
+	suite.Equal(http.StatusOK, rec.Code, rec.Body.String())
+
+	var resp handler.GenericDataListResponse[relational.SystemComponentSuggestion]
+	suite.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &resp))
+	suite.Empty(resp.Data, "controls outside the linked profiles' catalogs must not resolve")
+}
+
+// TestBulkApply_AmbiguousControlID_ScopedToLinkedCatalog verifies the scoping holds through
+// the bulk-apply path, which funnels every ImplementedRequirement through the same resolution.
+func (suite *SystemComponentSuggestionsIntegrationSuite) TestBulkApply_AmbiguousControlID_ScopedToLinkedCatalog() {
+	const controlID = "ac-1"
+	catalogA := suite.buildCatalogWithControl(controlID)
+	catalogB := suite.buildCatalogWithControl(controlID)
+
+	dcA, _ := suite.buildFilterAndEvidenceInCatalog(catalogA, controlID, "catalog-a-component")
+	suite.buildFilterAndEvidenceInCatalog(catalogB, controlID, "catalog-b-component")
+
+	sspID, _ := suite.buildSSP(controlID)
+	suite.linkSSPToProfileWithControls(sspID, catalogA, controlID)
+
+	rec, req := suite.req(http.MethodPost,
+		fmt.Sprintf("/api/oscal/system-security-plans/%s/bulk-apply-component-suggestions", sspID),
+		nil)
+	suite.server.E().ServeHTTP(rec, req)
+	suite.Equal(http.StatusNoContent, rec.Code, rec.Body.String())
+
+	var si relational.SystemImplementation
+	suite.Require().NoError(suite.DB.Where("system_security_plan_id = ?", sspID).First(&si).Error)
+
+	var components []relational.SystemComponent
+	suite.Require().NoError(suite.DB.
+		Where("system_implementation_id = ? AND defined_component_id IS NOT NULL", si.ID).
+		Find(&components).Error)
+	suite.Require().Len(components, 1, "bulk apply must only create components from the linked catalog")
+	suite.Equal(dcA, components[0].DefinedComponentID.String())
+}
+
 func (suite *SystemComponentSuggestionsIntegrationSuite) TestSuggestComponents_AlreadyLinkedExcluded() {
 	const controlID = "ac-4"
 	sspID, implReqID := suite.buildSSP(controlID)
@@ -514,6 +765,109 @@ func (suite *SystemComponentSuggestionsIntegrationSuite) TestApplySuggestion_Ide
 		Where("system_implementation_id = ? AND defined_component_id IS NOT NULL", si.ID).
 		Count(&count)
 	suite.Equal(int64(1), count, "duplicate SystemComponents must not be created")
+}
+
+// TestApplySuggestion_DoesNotRemoveSuggestionFromOtherRequirement guards the per-requirement
+// evaluation granularity: applying a suggestion on requirement A must not exclude the same
+// component from requirement B's suggestions when B's evidence also matches it.
+func (suite *SystemComponentSuggestionsIntegrationSuite) TestApplySuggestion_DoesNotRemoveSuggestionFromOtherRequirement() {
+	const (
+		controlA = "pr-1"
+		controlB = "pr-2"
+	)
+	sspID, implReqA, implReqB := suite.buildSSPWithTwoImplReqs(controlA, controlB)
+	dcUUID, compDefUUID := suite.buildSharedFilterAndEvidence(controlA, controlB)
+
+	suggestPath := func(reqID string) string {
+		return fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/suggest-components", sspID, reqID)
+	}
+
+	// Both requirements initially suggest the shared component
+	for _, reqID := range []string{implReqA, implReqB} {
+		rec, req := suite.req(http.MethodPost, suggestPath(reqID), nil)
+		suite.server.E().ServeHTTP(rec, req)
+		suite.Require().Equal(http.StatusOK, rec.Code, rec.Body.String())
+
+		var resp handler.GenericDataListResponse[relational.SystemComponentSuggestion]
+		suite.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &resp))
+		suite.Require().Len(resp.Data, 1, "requirement %s should initially suggest the shared component", reqID)
+	}
+
+	// Apply the suggestion on requirement A
+	rec, req := suite.req(http.MethodPost,
+		fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/apply-suggestion", sspID, implReqA),
+		map[string]any{
+			"component-definition-id": compDefUUID,
+			"defined-component-id":    dcUUID,
+		})
+	suite.server.E().ServeHTTP(rec, req)
+	suite.Require().Equal(http.StatusNoContent, rec.Code, rec.Body.String())
+
+	// Requirement A no longer suggests it
+	rec, req = suite.req(http.MethodPost, suggestPath(implReqA), nil)
+	suite.server.E().ServeHTTP(rec, req)
+	suite.Equal(http.StatusOK, rec.Code)
+	var respA handler.GenericDataListResponse[relational.SystemComponentSuggestion]
+	suite.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &respA))
+	suite.Empty(respA.Data, "requirement A should not suggest an already-linked component")
+
+	// Requirement B still suggests it
+	rec, req = suite.req(http.MethodPost, suggestPath(implReqB), nil)
+	suite.server.E().ServeHTTP(rec, req)
+	suite.Equal(http.StatusOK, rec.Code)
+	var respB handler.GenericDataListResponse[relational.SystemComponentSuggestion]
+	suite.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &respB))
+	suite.Require().Len(respB.Data, 1, "applying on requirement A must not remove the suggestion from requirement B")
+	suite.Equal(dcUUID, respB.Data[0].DefinedComponentID.String())
+}
+
+// TestApplySuggestion_SecondRequirementReusesSystemComponent guards the apply path: applying the
+// same component on a second requirement must reuse the existing SystemComponent and only add
+// the ByComponent link for the second requirement.
+func (suite *SystemComponentSuggestionsIntegrationSuite) TestApplySuggestion_SecondRequirementReusesSystemComponent() {
+	const (
+		controlA = "pr-3"
+		controlB = "pr-4"
+	)
+	sspID, implReqA, implReqB := suite.buildSSPWithTwoImplReqs(controlA, controlB)
+	dcUUID, compDefUUID := suite.buildSharedFilterAndEvidence(controlA, controlB)
+
+	// Apply the suggestion on both requirements
+	for _, reqID := range []string{implReqA, implReqB} {
+		rec, req := suite.req(http.MethodPost,
+			fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/apply-suggestion", sspID, reqID),
+			map[string]any{
+				"component-definition-id": compDefUUID,
+				"defined-component-id":    dcUUID,
+			})
+		suite.server.E().ServeHTTP(rec, req)
+		suite.Require().Equal(http.StatusNoContent, rec.Code, "apply on requirement %s: %s", reqID, rec.Body.String())
+	}
+
+	// Exactly one SystemComponent exists for the defined component
+	var si relational.SystemImplementation
+	suite.Require().NoError(suite.DB.Where("system_security_plan_id = ?", sspID).First(&si).Error)
+
+	var components []relational.SystemComponent
+	suite.Require().NoError(suite.DB.
+		Where("system_implementation_id = ? AND defined_component_id = ?", si.ID, dcUUID).
+		Find(&components).Error)
+	suite.Require().Len(components, 1, "applying on a second requirement must not create a duplicate SystemComponent")
+
+	// Two ByComponent links exist, one per requirement
+	var byComponents []relational.ByComponent
+	suite.Require().NoError(suite.DB.
+		Where("component_uuid = ?", components[0].ID).
+		Find(&byComponents).Error)
+	suite.Require().Len(byComponents, 2, "expected one ByComponent link per requirement")
+
+	parents := map[string]bool{}
+	for _, bc := range byComponents {
+		suite.Require().NotNil(bc.ParentID)
+		parents[bc.ParentID.String()] = true
+	}
+	suite.True(parents[implReqA], "missing ByComponent link for requirement A")
+	suite.True(parents[implReqB], "missing ByComponent link for requirement B")
 }
 
 func (suite *SystemComponentSuggestionsIntegrationSuite) TestApplySuggestion_SuggestionNotFound() {

--- a/internal/service/migrator.go
+++ b/internal/service/migrator.go
@@ -231,9 +231,33 @@ func MigrateUpWithConfig(db *gorm.DB, cfg *config.Config) error {
 		// while still allowing multiple rows with NULL defined_component_id
 		// The WHERE clause makes this a partial index that only enforces uniqueness when defined_component_id IS NOT NULL
 		if err := db.Exec(`
-			CREATE UNIQUE INDEX IF NOT EXISTS idx_system_components_unique_impl_defined 
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_system_components_unique_impl_defined
 			ON system_components (system_implementation_id, defined_component_id)
 			WHERE defined_component_id IS NOT NULL
+		`).Error; err != nil {
+			return err
+		}
+
+		// Align filter_controls.control_catalog_id (historically text) with
+		// profile_controls.control_catalog_id and controls.catalog_id, which are both uuid.
+		// The mismatch forced every catalog-scoped join (suggestion service, filter handler,
+		// risk evidence worker) to CAST around it. Idempotent and safe to run every boot:
+		// it only fires while the column is still text. NULLIF guards any legacy empty
+		// strings that ''::uuid would otherwise reject; real values are uuid.UUID.String().
+		if err := db.Exec(`
+			DO $$
+			BEGIN
+			  IF EXISTS (
+			    SELECT 1 FROM information_schema.columns
+			    WHERE table_name = 'filter_controls'
+			      AND column_name = 'control_catalog_id'
+			      AND data_type = 'text'
+			  ) THEN
+			    ALTER TABLE filter_controls
+			      ALTER COLUMN control_catalog_id TYPE uuid
+			      USING NULLIF(control_catalog_id, '')::uuid;
+			  END IF;
+			END $$;
 		`).Error; err != nil {
 			return err
 		}

--- a/internal/service/relational/system_component_suggestions.go
+++ b/internal/service/relational/system_component_suggestions.go
@@ -39,10 +39,24 @@ func NewSystemComponentSuggestionService(db *gorm.DB, evidenceSvc EvidenceQuerie
 
 // SuggestForImplementedRequirement finds DefinedComponents that are relevant to the control of the given
 // ImplementedRequirement by tracing the path: Control → Filter → Evidence → ComponentDefinitionLabels.
-// Components already present as SystemComponents in the SSP's SystemImplementation are excluded.
+// Components already linked to this ImplementedRequirement via a ByComponent entry are excluded;
+// components merely present elsewhere in the SSP's SystemImplementation are still suggested.
 func (s *SystemComponentSuggestionService) SuggestForImplementedRequirement(
 	sspID uuid.UUID,
 	implReqID uuid.UUID,
+) ([]SystemComponentSuggestion, error) {
+	return s.suggestForParent(sspID, implReqID, implReqID, "implemented_requirements")
+}
+
+// suggestForParent finds DefinedComponents relevant to the control of the given ImplementedRequirement
+// and excludes those already linked to the given parent (ImplementedRequirement or Statement) via
+// ByComponent. Exclusion is evaluated per parent, not per SSP: a component applied to one requirement
+// must still be suggested for other requirements whose evidence matches it.
+func (s *SystemComponentSuggestionService) suggestForParent(
+	sspID uuid.UUID,
+	implReqID uuid.UUID,
+	parentID uuid.UUID,
+	parentType string,
 ) ([]SystemComponentSuggestion, error) {
 	// 1. Get the SystemImplementation for this SSP
 	var systemImpl SystemImplementation
@@ -62,24 +76,42 @@ func (s *SystemComponentSuggestionService) SuggestForImplementedRequirement(
 
 	// 3. Load Filters associated with this control via the filter_controls join table.
 	//
-	// NOTE: We match Filters by control_id string only (case-insensitive), ignoring
-	// the catalog context (control_catalog_id column). This means Filters from
-	// different catalogs that share the same control ID string (e.g. "AC-1") will
-	// all be evaluated. In practice this is acceptable since control IDs rarely
-	// collide across catalogs used together.
+	// When the SSP is linked to profiles (via the ssp_profiles join table), resolution
+	// is scoped to the catalogs those profiles import: a filter_controls row only
+	// matches if its (control_catalog_id, control_id) pair appears in profile_controls
+	// for one of the SSP's profiles. This prevents controls that share the same ID
+	// string in different catalogs (e.g. "AC-1") from cross-matching, mirroring the
+	// catalog-scoped join used by RiskEvidenceWorker.
 	//
-	// TODO: To scope by catalog, join through:
-	//   SSP → ProfileID → Profile → resolved Catalog IDs → filter_controls.control_catalog_id
-	// This requires deriving the relevant catalog IDs from the SSP/profile and including
-	// filter_controls.control_catalog_id in the join conditions.
-	var filters []Filter
+	// SSPs without linked profiles carry no catalog scope to resolve against, so they
+	// fall back to a global case-insensitive match on the control ID string.
+	var linkedProfileCount int64
 	if err := s.db.
+		Table("ssp_profiles").
+		Where("system_security_plan_id = ?", sspID).
+		Count(&linkedProfileCount).Error; err != nil {
+		return nil, fmt.Errorf("failed to count linked profiles for SSP %s: %w", sspID, err)
+	}
+
+	filterQuery := s.db.
 		Joins("JOIN filter_controls ON filter_controls.filter_id = filters.id").
 		// Normalize on upper case.
 		// We don't need to concern about index hits as for now - these tables will not grow
 		// on a typical CCF usage.
 		Where("UPPER(filter_controls.control_id) = UPPER(?)", implReq.ControlId).
-		Find(&filters).Error; err != nil {
+		// A Filter may reference the same control ID in several catalogs; collapse duplicates.
+		Group("filters.id")
+	if linkedProfileCount > 0 {
+		filterQuery = filterQuery.
+			// profile_controls.control_catalog_id is uuid while filter_controls.control_catalog_id
+			// is text (inconsistent join-table generation); compare both as text.
+			Joins("JOIN profile_controls ON CAST(profile_controls.control_catalog_id AS text) = CAST(filter_controls.control_catalog_id AS text) AND UPPER(profile_controls.control_id) = UPPER(filter_controls.control_id)").
+			Joins("JOIN ssp_profiles ON ssp_profiles.profile_id = profile_controls.profile_id").
+			Where("ssp_profiles.system_security_plan_id = ?", sspID)
+	}
+
+	var filters []Filter
+	if err := filterQuery.Find(&filters).Error; err != nil {
 		return nil, fmt.Errorf("failed to query filters for control %s: %w", implReq.ControlId, err)
 	}
 
@@ -143,14 +175,18 @@ func (s *SystemComponentSuggestionService) SuggestForImplementedRequirement(
 		candidateIDs[i] = *c.ID
 	}
 
-	// 7. Find existing SystemComponents in this SystemImplementation that are already linked
-	//    to one of the candidate DefinedComponents
+	// 7. Find candidate DefinedComponents already linked to THIS parent via a ByComponent entry.
+	//    Components that only exist as SystemComponents elsewhere in the SystemImplementation
+	//    (linked to other requirements/statements) remain suggestible here: applying them again
+	//    reuses the existing SystemComponent and only adds the missing ByComponent link.
 	var existingIDs []uuid.UUID
 	if err := s.db.
-		Model(&SystemComponent{}).
-		Where("system_implementation_id = ? AND defined_component_id IN ?", systemImplID, candidateIDs).
-		Pluck("defined_component_id", &existingIDs).Error; err != nil {
-		return nil, fmt.Errorf("failed to query existing system components: %w", err)
+		Table("by_components").
+		Joins("JOIN system_components ON system_components.id = by_components.component_uuid").
+		Where("system_components.system_implementation_id = ? AND system_components.defined_component_id IN ?", systemImplID, candidateIDs).
+		Where("by_components.parent_id = ? AND by_components.parent_type = ?", parentID, parentType).
+		Pluck("system_components.defined_component_id", &existingIDs).Error; err != nil {
+		return nil, fmt.Errorf("failed to query existing by-component links: %w", err)
 	}
 
 	existingSet := make(map[uuid.UUID]struct{}, len(existingIDs))
@@ -158,7 +194,7 @@ func (s *SystemComponentSuggestionService) SuggestForImplementedRequirement(
 		existingSet[id] = struct{}{}
 	}
 
-	// 8. Build suggestions from candidates not already present
+	// 8. Build suggestions from candidates not already linked to this parent
 	suggestions := make([]SystemComponentSuggestion, 0, len(candidates))
 	for _, c := range candidates {
 		if _, alreadyLinked := existingSet[*c.ID]; alreadyLinked {
@@ -182,7 +218,8 @@ func (s *SystemComponentSuggestionService) SuggestForImplementedRequirement(
 }
 
 // SuggestForStatement returns the same candidate components as the parent ImplementedRequirement,
-// after validating that the statement belongs to the given requirement and SSP.
+// after validating that the statement belongs to the given requirement and SSP. Exclusion is
+// evaluated against the statement's own ByComponent links, not the requirement's.
 func (s *SystemComponentSuggestionService) SuggestForStatement(
 	sspID uuid.UUID,
 	implReqID uuid.UUID,
@@ -191,7 +228,7 @@ func (s *SystemComponentSuggestionService) SuggestForStatement(
 	if err := s.validateStatementForImplementedRequirement(sspID, implReqID, stmtID); err != nil {
 		return nil, err
 	}
-	return s.SuggestForImplementedRequirement(sspID, implReqID)
+	return s.suggestForParent(sspID, implReqID, stmtID, "statements")
 }
 
 // ApplyForImplementedRequirement creates missing SystemComponents for all suggestions related to the given
@@ -267,7 +304,7 @@ func (s *SystemComponentSuggestionService) applyForParent(
 		return err
 	}
 
-	suggestions, err := s.SuggestForImplementedRequirement(sspID, implReqID)
+	suggestions, err := s.suggestForParent(sspID, implReqID, parentID, parentType)
 	if err != nil {
 		return err
 	}
@@ -310,7 +347,7 @@ func (s *SystemComponentSuggestionService) applySuggestionForParent(
 		)
 	}
 
-	suggestions, err := s.SuggestForImplementedRequirement(sspID, implReqID)
+	suggestions, err := s.suggestForParent(sspID, implReqID, parentID, parentType)
 	if err != nil {
 		return err
 	}
@@ -391,13 +428,17 @@ func (s *SystemComponentSuggestionService) ensureSystemComponent(
 	}
 
 	// Load the component to get its ID (either newly created or existing).
+	// Use a fresh struct: after a no-op conflict, `component` still carries the UUID
+	// generated by BeforeCreate, and First would add that primary key to the WHERE
+	// clause, hiding the existing row.
+	var persisted SystemComponent
 	if err := tx.
 		Where("system_implementation_id = ? AND defined_component_id = ?", systemImplID, definedComponentID).
-		First(&component).Error; err != nil {
+		First(&persisted).Error; err != nil {
 		return nil, fmt.Errorf("failed to load system component for defined component %s: %w", definedComponentID, err)
 	}
 
-	return &component, nil
+	return &persisted, nil
 }
 
 func (s *SystemComponentSuggestionService) ensureByComponentLink(

--- a/internal/service/relational/system_component_suggestions.go
+++ b/internal/service/relational/system_component_suggestions.go
@@ -109,11 +109,10 @@ func (s *SystemComponentSuggestionService) suggestForParent(
 		Group("filters.id")
 	if scopedControlCount > 0 {
 		filterQuery = filterQuery.
-			// profile_controls.control_catalog_id is uuid while filter_controls.control_catalog_id
-			// is text (inconsistent join-table generation); compare both as text. Postgres renders
-			// uuid::text as canonical lower-case, but filter_controls holds free text, so lower-case
-			// both sides to stay robust if a catalog UUID was ever written upper-cased.
-			Joins("JOIN profile_controls ON LOWER(CAST(profile_controls.control_catalog_id AS text)) = LOWER(CAST(filter_controls.control_catalog_id AS text)) AND UPPER(profile_controls.control_id) = UPPER(filter_controls.control_id)").
+			// filter_controls.control_catalog_id and profile_controls.control_catalog_id are
+			// both uuid (aligned by the filter_controls type migration in MigrateUpWithConfig),
+			// so they compare directly. control_id remains free text, hence the UPPER() fold.
+			Joins("JOIN profile_controls ON profile_controls.control_catalog_id = filter_controls.control_catalog_id AND UPPER(profile_controls.control_id) = UPPER(filter_controls.control_id)").
 			Joins("JOIN ssp_profiles ON ssp_profiles.profile_id = profile_controls.profile_id").
 			Where("ssp_profiles.system_security_plan_id = ?", sspID)
 	}

--- a/internal/service/relational/system_component_suggestions.go
+++ b/internal/service/relational/system_component_suggestions.go
@@ -76,21 +76,27 @@ func (s *SystemComponentSuggestionService) suggestForParent(
 
 	// 3. Load Filters associated with this control via the filter_controls join table.
 	//
-	// When the SSP is linked to profiles (via the ssp_profiles join table), resolution
-	// is scoped to the catalogs those profiles import: a filter_controls row only
-	// matches if its (control_catalog_id, control_id) pair appears in profile_controls
+	// When the SSP's linked profiles have resolved controls (rows in profile_controls),
+	// resolution is scoped to the catalogs those profiles import: a filter_controls row
+	// only matches if its (control_catalog_id, control_id) pair appears in profile_controls
 	// for one of the SSP's profiles. This prevents controls that share the same ID
 	// string in different catalogs (e.g. "AC-1") from cross-matching, mirroring the
 	// catalog-scoped join used by RiskEvidenceWorker.
 	//
-	// SSPs without linked profiles carry no catalog scope to resolve against, so they
-	// fall back to a global case-insensitive match on the control ID string.
-	var linkedProfileCount int64
+	// We gate on the presence of profile_controls reachable through ssp_profiles, not on
+	// ssp_profiles alone: an SSP may be linked to a profile whose controls have not been
+	// resolved yet (SyncProfileControls not run, aborted via the stale-sync guard, or a
+	// profile that resolves to zero controls). Such an SSP carries no catalog scope to
+	// enforce, so it falls back to a global case-insensitive match on the control ID
+	// string, mirroring getControlIDsForProfile's empty-pivot fallback. Gating on
+	// ssp_profiles alone would instead resolve to nothing in that window.
+	var scopedControlCount int64
 	if err := s.db.
-		Table("ssp_profiles").
-		Where("system_security_plan_id = ?", sspID).
-		Count(&linkedProfileCount).Error; err != nil {
-		return nil, fmt.Errorf("failed to count linked profiles for SSP %s: %w", sspID, err)
+		Table("profile_controls").
+		Joins("JOIN ssp_profiles ON ssp_profiles.profile_id = profile_controls.profile_id").
+		Where("ssp_profiles.system_security_plan_id = ?", sspID).
+		Count(&scopedControlCount).Error; err != nil {
+		return nil, fmt.Errorf("failed to count scoped profile controls for SSP %s: %w", sspID, err)
 	}
 
 	filterQuery := s.db.
@@ -101,7 +107,7 @@ func (s *SystemComponentSuggestionService) suggestForParent(
 		Where("UPPER(filter_controls.control_id) = UPPER(?)", implReq.ControlId).
 		// A Filter may reference the same control ID in several catalogs; collapse duplicates.
 		Group("filters.id")
-	if linkedProfileCount > 0 {
+	if scopedControlCount > 0 {
 		filterQuery = filterQuery.
 			// profile_controls.control_catalog_id is uuid while filter_controls.control_catalog_id
 			// is text (inconsistent join-table generation); compare both as text. Postgres renders

--- a/internal/service/relational/system_component_suggestions.go
+++ b/internal/service/relational/system_component_suggestions.go
@@ -104,8 +104,10 @@ func (s *SystemComponentSuggestionService) suggestForParent(
 	if linkedProfileCount > 0 {
 		filterQuery = filterQuery.
 			// profile_controls.control_catalog_id is uuid while filter_controls.control_catalog_id
-			// is text (inconsistent join-table generation); compare both as text.
-			Joins("JOIN profile_controls ON CAST(profile_controls.control_catalog_id AS text) = CAST(filter_controls.control_catalog_id AS text) AND UPPER(profile_controls.control_id) = UPPER(filter_controls.control_id)").
+			// is text (inconsistent join-table generation); compare both as text. Postgres renders
+			// uuid::text as canonical lower-case, but filter_controls holds free text, so lower-case
+			// both sides to stay robust if a catalog UUID was ever written upper-cased.
+			Joins("JOIN profile_controls ON LOWER(CAST(profile_controls.control_catalog_id AS text)) = LOWER(CAST(filter_controls.control_catalog_id AS text)) AND UPPER(profile_controls.control_id) = UPPER(filter_controls.control_id)").
 			Joins("JOIN ssp_profiles ON ssp_profiles.profile_id = profile_controls.profile_id").
 			Where("ssp_profiles.system_security_plan_id = ?", sspID)
 	}

--- a/internal/service/relational/system_component_suggestions_test.go
+++ b/internal/service/relational/system_component_suggestions_test.go
@@ -538,6 +538,29 @@ func TestSuggestForImplementedRequirement_ScopedToLinkedCatalog_CatalogIDCaseIns
 	assert.Equal(t, *dc.ID, suggestions[0].DefinedComponentID)
 }
 
+func TestSuggestForImplementedRequirement_LinkedProfileWithoutResolvedControls_GlobalFallback(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewSystemComponentSuggestionService(db, &scopedEvidenceQuerier{db: db})
+
+	catalogA, catalogB := uuid.New(), uuid.New()
+	dcA, dcB := seedAmbiguousControlInTwoCatalogs(t, db, catalogA, catalogB)
+
+	// The SSP is linked to a profile (ssp_profiles has a row) but the profile has no
+	// resolved controls yet (profile_controls is empty) — e.g. SyncProfileControls has
+	// not run, aborted via the stale-sync guard, or the profile resolves to zero controls.
+	// There is no catalog scope to enforce, so resolution must fall back to global
+	// matching, mirroring getControlIDsForProfile's empty-pivot fallback.
+	sspID, implReqID := seedSSPWithImplReq(t, db, "ac-1")
+	linkSSPToProfileWithControls(t, db, sspID, catalogA) // no control IDs → no profile_controls rows
+
+	suggestions, err := svc.SuggestForImplementedRequirement(sspID, implReqID)
+	require.NoError(t, err)
+	require.Len(t, suggestions, 2, "a profile with no resolved controls carries no scope; both catalogs' components should be suggested")
+	ids := []uuid.UUID{suggestions[0].DefinedComponentID, suggestions[1].DefinedComponentID}
+	assert.Contains(t, ids, *dcA.ID)
+	assert.Contains(t, ids, *dcB.ID)
+}
+
 func TestSuggestForImplementedRequirement_LinkedToSameRequirementExcluded(t *testing.T) {
 	db := setupTestDB(t)
 	svc := NewSystemComponentSuggestionService(db, &mockEvidenceQuerier{db: db})

--- a/internal/service/relational/system_component_suggestions_test.go
+++ b/internal/service/relational/system_component_suggestions_test.go
@@ -2,7 +2,6 @@ package relational
 
 import (
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -510,32 +509,6 @@ func TestSuggestForImplementedRequirement_LinkedProfileWithoutControl_NoSuggesti
 	suggestions, err := svc.SuggestForImplementedRequirement(sspID, implReqID)
 	require.NoError(t, err)
 	assert.Empty(t, suggestions, "controls outside the linked profiles' catalogs must not resolve")
-}
-
-func TestSuggestForImplementedRequirement_ScopedToLinkedCatalog_CatalogIDCaseInsensitive(t *testing.T) {
-	db := setupTestDB(t)
-	svc := NewSystemComponentSuggestionService(db, &scopedEvidenceQuerier{db: db})
-
-	catalog := uuid.New()
-	dc := seedDefinedComponentWithLabels(t, db, "plugin", "component-a")
-	seedFilterForControlInCatalog(t, db, catalog, "ac-1", "plugin", "component-a")
-	seedEvidenceWithLabel(t, db, "plugin", "component-a")
-
-	// filter_controls holds the catalog UUID upper-cased while profile_controls (via the
-	// link below) holds it lower-case, as Postgres uuid::text renders it. The scoped join
-	// must still match across the case difference.
-	require.NoError(t, db.Exec(
-		`UPDATE filter_controls SET control_catalog_id = ? WHERE control_catalog_id = ?`,
-		strings.ToUpper(catalog.String()), catalog.String(),
-	).Error)
-
-	sspID, implReqID := seedSSPWithImplReq(t, db, "ac-1")
-	linkSSPToProfileWithControls(t, db, sspID, catalog, "ac-1")
-
-	suggestions, err := svc.SuggestForImplementedRequirement(sspID, implReqID)
-	require.NoError(t, err)
-	require.Len(t, suggestions, 1, "catalog ID case must not affect scoped resolution")
-	assert.Equal(t, *dc.ID, suggestions[0].DefinedComponentID)
 }
 
 func TestSuggestForImplementedRequirement_LinkedProfileWithoutResolvedControls_GlobalFallback(t *testing.T) {

--- a/internal/service/relational/system_component_suggestions_test.go
+++ b/internal/service/relational/system_component_suggestions_test.go
@@ -2,6 +2,7 @@ package relational
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -509,6 +510,32 @@ func TestSuggestForImplementedRequirement_LinkedProfileWithoutControl_NoSuggesti
 	suggestions, err := svc.SuggestForImplementedRequirement(sspID, implReqID)
 	require.NoError(t, err)
 	assert.Empty(t, suggestions, "controls outside the linked profiles' catalogs must not resolve")
+}
+
+func TestSuggestForImplementedRequirement_ScopedToLinkedCatalog_CatalogIDCaseInsensitive(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewSystemComponentSuggestionService(db, &scopedEvidenceQuerier{db: db})
+
+	catalog := uuid.New()
+	dc := seedDefinedComponentWithLabels(t, db, "plugin", "component-a")
+	seedFilterForControlInCatalog(t, db, catalog, "ac-1", "plugin", "component-a")
+	seedEvidenceWithLabel(t, db, "plugin", "component-a")
+
+	// filter_controls holds the catalog UUID upper-cased while profile_controls (via the
+	// link below) holds it lower-case, as Postgres uuid::text renders it. The scoped join
+	// must still match across the case difference.
+	require.NoError(t, db.Exec(
+		`UPDATE filter_controls SET control_catalog_id = ? WHERE control_catalog_id = ?`,
+		strings.ToUpper(catalog.String()), catalog.String(),
+	).Error)
+
+	sspID, implReqID := seedSSPWithImplReq(t, db, "ac-1")
+	linkSSPToProfileWithControls(t, db, sspID, catalog, "ac-1")
+
+	suggestions, err := svc.SuggestForImplementedRequirement(sspID, implReqID)
+	require.NoError(t, err)
+	require.Len(t, suggestions, 1, "catalog ID case must not affect scoped resolution")
+	assert.Equal(t, *dc.ID, suggestions[0].DefinedComponentID)
 }
 
 func TestSuggestForImplementedRequirement_LinkedToSameRequirementExcluded(t *testing.T) {

--- a/internal/service/relational/system_component_suggestions_test.go
+++ b/internal/service/relational/system_component_suggestions_test.go
@@ -34,6 +34,39 @@ func (m *mockEvidenceQuerier) GetLatestForFilters(_ ...labelfilter.Filter) ([]Ev
 	return evidences, nil
 }
 
+// scopedEvidenceQuerier honours the simple label=value condition of each filter,
+// returning only evidence whose labels match. Catalog-scoping tests need this:
+// they assert that excluding a catalog's Filter also excludes its evidence, which
+// the indiscriminate mockEvidenceQuerier cannot express.
+type scopedEvidenceQuerier struct {
+	db *gorm.DB
+}
+
+func (m *scopedEvidenceQuerier) GetLatestForFilters(filters ...labelfilter.Filter) ([]Evidence, error) {
+	seen := make(map[uuid.UUID]struct{})
+	out := make([]Evidence, 0)
+	for _, f := range filters {
+		if f.Scope == nil || f.Scope.Condition == nil {
+			continue
+		}
+		var evidences []Evidence
+		if err := m.db.
+			Joins("JOIN evidence_labels el ON el.evidence_id = evidences.id").
+			Where("el.labels_name = ? AND el.labels_value = ?", f.Scope.Condition.Label, f.Scope.Condition.Value).
+			Find(&evidences).Error; err != nil {
+			return nil, err
+		}
+		for _, e := range evidences {
+			if _, ok := seen[*e.ID]; ok {
+				continue
+			}
+			seen[*e.ID] = struct{}{}
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
 // ---------------------------------------------------------------------------
 // Test DB setup
 // ---------------------------------------------------------------------------
@@ -117,6 +150,18 @@ func setupTestDB(t *testing.T) *gorm.DB {
 			value TEXT
 		)`).Error)
 
+	require.NoError(t, db.Exec(`CREATE TABLE IF NOT EXISTS profile_controls (
+		profile_id TEXT,
+		control_catalog_id TEXT,
+		control_id TEXT
+	)`).Error)
+
+	require.NoError(t, db.Exec(`CREATE TABLE IF NOT EXISTS ssp_profiles (
+		system_security_plan_id TEXT,
+		profile_id TEXT,
+		PRIMARY KEY (system_security_plan_id, profile_id)
+	)`).Error)
+
 	return db
 }
 
@@ -127,6 +172,13 @@ func setupTestDB(t *testing.T) *gorm.DB {
 // seedFilterForControl inserts a Filter record and a filter_controls row linking it
 // to the given controlID string. Returns the Filter ID.
 func seedFilterForControl(t *testing.T, db *gorm.DB, controlID, labelKey, labelValue string) uuid.UUID {
+	t.Helper()
+	return seedFilterForControlInCatalog(t, db, uuid.Nil, controlID, labelKey, labelValue)
+}
+
+// seedFilterForControlInCatalog inserts a Filter record and a filter_controls row linking it
+// to the given (catalogID, controlID) pair. Returns the Filter ID.
+func seedFilterForControlInCatalog(t *testing.T, db *gorm.DB, catalogID uuid.UUID, controlID, labelKey, labelValue string) uuid.UUID {
 	t.Helper()
 	filterID := uuid.New()
 	lf := labelfilter.Filter{
@@ -149,10 +201,32 @@ func seedFilterForControl(t *testing.T, db *gorm.DB, controlID, labelKey, labelV
 
 	require.NoError(t, db.Exec(
 		`INSERT INTO filter_controls (filter_id, control_catalog_id, control_id) VALUES (?, ?, ?)`,
-		filterID, uuid.Nil, controlID,
+		filterID, catalogID, controlID,
 	).Error)
 
 	return filterID
+}
+
+// linkSSPToProfileWithControls links the SSP to a new profile via ssp_profiles and
+// registers each (catalogID, controlID) pair in profile_controls, scoping the SSP's
+// control resolution to that catalog. Returns the profile ID.
+func linkSSPToProfileWithControls(t *testing.T, db *gorm.DB, sspID, catalogID uuid.UUID, controlIDs ...string) uuid.UUID {
+	t.Helper()
+	profileID := uuid.New()
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO ssp_profiles (system_security_plan_id, profile_id) VALUES (?, ?)`,
+		sspID, profileID,
+	).Error)
+
+	for _, controlID := range controlIDs {
+		require.NoError(t, db.Exec(
+			`INSERT INTO profile_controls (profile_id, control_catalog_id, control_id) VALUES (?, ?, ?)`,
+			profileID, catalogID, controlID,
+		).Error)
+	}
+
+	return profileID
 }
 
 // seedEvidenceWithLabel inserts an Evidence record and an evidence_labels row.
@@ -354,7 +428,90 @@ func TestSuggestForImplementedRequirement_CaseInsensitiveControlID(t *testing.T)
 	assert.Equal(t, *dc.ID, suggestions[0].DefinedComponentID)
 }
 
-func TestSuggestForImplementedRequirement_AlreadyLinkedFiltered(t *testing.T) {
+// catalog-scoping tests: the same control ID ("ac-1") exists in two catalogs, each
+// with its own Filter/Evidence/DefinedComponent chain. Returns both components.
+func seedAmbiguousControlInTwoCatalogs(t *testing.T, db *gorm.DB, catalogA, catalogB uuid.UUID) (dcA, dcB DefinedComponent) {
+	t.Helper()
+	dcA = seedDefinedComponentWithLabels(t, db, "plugin", "component-a")
+	seedFilterForControlInCatalog(t, db, catalogA, "ac-1", "plugin", "component-a")
+	seedEvidenceWithLabel(t, db, "plugin", "component-a")
+
+	dcB = seedDefinedComponentWithLabels(t, db, "plugin", "component-b")
+	seedFilterForControlInCatalog(t, db, catalogB, "AC-1", "plugin", "component-b")
+	seedEvidenceWithLabel(t, db, "plugin", "component-b")
+	return dcA, dcB
+}
+
+func TestSuggestForImplementedRequirement_ScopedToLinkedCatalog(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewSystemComponentSuggestionService(db, &scopedEvidenceQuerier{db: db})
+
+	catalogA, catalogB := uuid.New(), uuid.New()
+	dcA, _ := seedAmbiguousControlInTwoCatalogs(t, db, catalogA, catalogB)
+
+	// SSP linked to a profile that imports "ac-1" from catalog A only
+	sspID, implReqID := seedSSPWithImplReq(t, db, "ac-1")
+	linkSSPToProfileWithControls(t, db, sspID, catalogA, "ac-1")
+
+	suggestions, err := svc.SuggestForImplementedRequirement(sspID, implReqID)
+	require.NoError(t, err)
+	require.Len(t, suggestions, 1, "only the component from the linked catalog should be suggested")
+	assert.Equal(t, *dcA.ID, suggestions[0].DefinedComponentID)
+}
+
+func TestSuggestForImplementedRequirement_ScopedToLinkedCatalog_CaseInsensitive(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewSystemComponentSuggestionService(db, &scopedEvidenceQuerier{db: db})
+
+	catalogA, catalogB := uuid.New(), uuid.New()
+	_, dcB := seedAmbiguousControlInTwoCatalogs(t, db, catalogA, catalogB)
+
+	// Profile registers the control lowercase while the catalog-B filter uses "AC-1"
+	sspID, implReqID := seedSSPWithImplReq(t, db, "AC-1")
+	linkSSPToProfileWithControls(t, db, sspID, catalogB, "ac-1")
+
+	suggestions, err := svc.SuggestForImplementedRequirement(sspID, implReqID)
+	require.NoError(t, err)
+	require.Len(t, suggestions, 1)
+	assert.Equal(t, *dcB.ID, suggestions[0].DefinedComponentID)
+}
+
+func TestSuggestForImplementedRequirement_NoLinkedProfiles_GlobalFallback(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewSystemComponentSuggestionService(db, &scopedEvidenceQuerier{db: db})
+
+	catalogA, catalogB := uuid.New(), uuid.New()
+	dcA, dcB := seedAmbiguousControlInTwoCatalogs(t, db, catalogA, catalogB)
+
+	// SSP without linked profiles: no catalog scope, so both catalogs' components match
+	sspID, implReqID := seedSSPWithImplReq(t, db, "ac-1")
+
+	suggestions, err := svc.SuggestForImplementedRequirement(sspID, implReqID)
+	require.NoError(t, err)
+	require.Len(t, suggestions, 2)
+	ids := []uuid.UUID{suggestions[0].DefinedComponentID, suggestions[1].DefinedComponentID}
+	assert.Contains(t, ids, *dcA.ID)
+	assert.Contains(t, ids, *dcB.ID)
+}
+
+func TestSuggestForImplementedRequirement_LinkedProfileWithoutControl_NoSuggestions(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewSystemComponentSuggestionService(db, &scopedEvidenceQuerier{db: db})
+
+	catalogA, catalogB := uuid.New(), uuid.New()
+	seedAmbiguousControlInTwoCatalogs(t, db, catalogA, catalogB)
+
+	// The SSP's profile imports a different control from catalog A, so "ac-1"
+	// resolves to no catalog in scope and nothing is suggested.
+	sspID, implReqID := seedSSPWithImplReq(t, db, "ac-1")
+	linkSSPToProfileWithControls(t, db, sspID, catalogA, "si-4")
+
+	suggestions, err := svc.SuggestForImplementedRequirement(sspID, implReqID)
+	require.NoError(t, err)
+	assert.Empty(t, suggestions, "controls outside the linked profiles' catalogs must not resolve")
+}
+
+func TestSuggestForImplementedRequirement_LinkedToSameRequirementExcluded(t *testing.T) {
 	db := setupTestDB(t)
 	svc := NewSystemComponentSuggestionService(db, &mockEvidenceQuerier{db: db})
 
@@ -364,11 +521,28 @@ func TestSuggestForImplementedRequirement_AlreadyLinkedFiltered(t *testing.T) {
 	seedEvidenceWithLabel(t, db, labelKey, labelValue)
 	sspID, implReqID := seedSSPWithImplReq(t, db, "ac-1")
 
-	// Get the SystemImplementation ID to create a pre-existing SystemComponent
+	// Apply the suggestion so the component is linked to THIS requirement via ByComponent
+	require.NoError(t, svc.ApplySuggestionForImplementedRequirement(sspID, implReqID, *dc.ComponentDefinitionID, *dc.ID))
+
+	suggestions, err := svc.SuggestForImplementedRequirement(sspID, implReqID)
+	require.NoError(t, err)
+	assert.Empty(t, suggestions, "component linked to this requirement should not appear as suggestion")
+}
+
+func TestSuggestForImplementedRequirement_ExistingSystemComponentWithoutLinkStillSuggested(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewSystemComponentSuggestionService(db, &mockEvidenceQuerier{db: db})
+
+	const labelKey, labelValue = "plugin", "nginx"
+	dc := seedDefinedComponentWithLabels(t, db, labelKey, labelValue)
+	seedFilterForControl(t, db, "ac-1", labelKey, labelValue)
+	seedEvidenceWithLabel(t, db, labelKey, labelValue)
+	sspID, implReqID := seedSSPWithImplReq(t, db, "ac-1")
+
 	var systemImpl SystemImplementation
 	require.NoError(t, db.Where("system_security_plan_id = ?", sspID).First(&systemImpl).Error)
 
-	// Pre-create a SystemComponent that is already linked to the DefinedComponent
+	// Pre-create a SystemComponent for the DefinedComponent, but without any ByComponent link
 	existing := SystemComponent{
 		Type:                   dc.Type,
 		Title:                  dc.Title,
@@ -381,7 +555,39 @@ func TestSuggestForImplementedRequirement_AlreadyLinkedFiltered(t *testing.T) {
 
 	suggestions, err := svc.SuggestForImplementedRequirement(sspID, implReqID)
 	require.NoError(t, err)
-	assert.Empty(t, suggestions, "component already linked should not appear as suggestion")
+	require.Len(t, suggestions, 1, "component present in the SSP but not linked to this requirement should still be suggested")
+	assert.Equal(t, *dc.ID, suggestions[0].DefinedComponentID)
+}
+
+func TestSuggestForImplementedRequirement_LinkedToOtherRequirementStillSuggested(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewSystemComponentSuggestionService(db, &mockEvidenceQuerier{db: db})
+
+	// One DefinedComponent whose evidence matches the controls of two requirements
+	const labelKey, labelValue = "plugin", "nginx"
+	dc := seedDefinedComponentWithLabels(t, db, labelKey, labelValue)
+	seedFilterForControl(t, db, "ac-1", labelKey, labelValue)
+	seedFilterForControl(t, db, "ac-2", labelKey, labelValue)
+	seedEvidenceWithLabel(t, db, labelKey, labelValue)
+
+	sspID, implReqA := seedSSPWithImplReq(t, db, "ac-1")
+	var ci ControlImplementation
+	require.NoError(t, db.Where("system_security_plan_id = ?", sspID).First(&ci).Error)
+	implReqB := ImplementedRequirement{ControlId: "ac-2", ControlImplementationId: *ci.ID}
+	require.NoError(t, db.Create(&implReqB).Error)
+
+	// Apply the suggestion on requirement A only
+	require.NoError(t, svc.ApplySuggestionForImplementedRequirement(sspID, implReqA, *dc.ComponentDefinitionID, *dc.ID))
+
+	// Requirement A no longer suggests it, requirement B still does
+	suggestionsA, err := svc.SuggestForImplementedRequirement(sspID, implReqA)
+	require.NoError(t, err)
+	assert.Empty(t, suggestionsA)
+
+	suggestionsB, err := svc.SuggestForImplementedRequirement(sspID, *implReqB.ID)
+	require.NoError(t, err)
+	require.Len(t, suggestionsB, 1, "component linked to another requirement must still be suggested here")
+	assert.Equal(t, *dc.ID, suggestionsB[0].DefinedComponentID)
 }
 
 func TestSuggestForImplementedRequirement_MultipleComponents(t *testing.T) {
@@ -497,6 +703,33 @@ func TestSuggestForStatement_ReturnsMatchingComponent(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, suggestions, 1)
 	assert.Equal(t, *dc.ID, suggestions[0].DefinedComponentID)
+}
+
+func TestSuggestForStatement_EvaluatedPerStatement(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewSystemComponentSuggestionService(db, &mockEvidenceQuerier{db: db})
+
+	const labelKey, labelValue = "plugin", "sshd"
+	dc := seedDefinedComponentWithLabels(t, db, labelKey, labelValue)
+	seedFilterForControl(t, db, "ac-1", labelKey, labelValue)
+	seedEvidenceWithLabel(t, db, labelKey, labelValue)
+	sspID, implReqID := seedSSPWithImplReq(t, db, "ac-1")
+	stmtID := seedStatementForImplReq(t, db, implReqID, "ac-1_smt.a")
+
+	// Linking the component to the parent requirement must not exclude it for the statement
+	require.NoError(t, svc.ApplySuggestionForImplementedRequirement(sspID, implReqID, *dc.ComponentDefinitionID, *dc.ID))
+
+	suggestions, err := svc.SuggestForStatement(sspID, implReqID, stmtID)
+	require.NoError(t, err)
+	require.Len(t, suggestions, 1, "component linked to the requirement should still be suggested for its statement")
+	assert.Equal(t, *dc.ID, suggestions[0].DefinedComponentID)
+
+	// Once linked to the statement itself, it is excluded for the statement
+	require.NoError(t, svc.ApplySuggestionForStatement(sspID, implReqID, stmtID, *dc.ComponentDefinitionID, *dc.ID))
+
+	suggestions, err = svc.SuggestForStatement(sspID, implReqID, stmtID)
+	require.NoError(t, err)
+	assert.Empty(t, suggestions, "component linked to this statement should not appear as suggestion")
 }
 
 func TestSuggestForStatement_NotFound(t *testing.T) {

--- a/internal/service/worker/risk_evidence_worker.go
+++ b/internal/service/worker/risk_evidence_worker.go
@@ -202,7 +202,9 @@ func (w *RiskEvidenceWorker) resolveSSPsViaFilters(ctx context.Context, evidence
 	if err := w.db.WithContext(ctx).
 		Table("filter_controls fc").
 		Select("DISTINCT ssp.id AS system_security_plan_id, fc.control_catalog_id, fc.control_id").
-		Joins("JOIN profile_controls pc ON CAST(pc.control_catalog_id AS uuid) = CAST(fc.control_catalog_id AS uuid) AND UPPER(pc.control_id) = UPPER(fc.control_id)").
+		// fc.control_catalog_id and pc.control_catalog_id are both uuid (filter_controls aligned
+		// by the type migration in MigrateUpWithConfig), so they compare directly.
+		Joins("JOIN profile_controls pc ON pc.control_catalog_id = fc.control_catalog_id AND UPPER(pc.control_id) = UPPER(fc.control_id)").
 		Joins("JOIN ssp_profiles sp ON CAST(sp.profile_id AS uuid) = CAST(pc.profile_id AS uuid)").
 		Joins("JOIN system_security_plans ssp ON CAST(ssp.id AS uuid) = CAST(sp.system_security_plan_id AS uuid)").
 		Joins("JOIN control_implementations ci ON CAST(ci.system_security_plan_id AS uuid) = CAST(ssp.id AS uuid)").

--- a/internal/tests/migrate.go
+++ b/internal/tests/migrate.go
@@ -196,9 +196,29 @@ func (t *TestMigrator) Up() error {
 	if t.db.Name() == "postgres" {
 		// Partial unique index for system_components
 		if err := t.db.Exec(`
-			CREATE UNIQUE INDEX IF NOT EXISTS idx_system_components_unique_impl_defined 
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_system_components_unique_impl_defined
 			ON system_components (system_implementation_id, defined_component_id)
 			WHERE defined_component_id IS NOT NULL
+		`).Error; err != nil {
+			return err
+		}
+
+		// Align filter_controls.control_catalog_id to uuid (matching production migration in
+		// service.MigrateUpWithConfig) so integration tests exercise the same uuid join path.
+		if err := t.db.Exec(`
+			DO $$
+			BEGIN
+			  IF EXISTS (
+			    SELECT 1 FROM information_schema.columns
+			    WHERE table_name = 'filter_controls'
+			      AND column_name = 'control_catalog_id'
+			      AND data_type = 'text'
+			  ) THEN
+			    ALTER TABLE filter_controls
+			      ALTER COLUMN control_catalog_id TYPE uuid
+			      USING NULLIF(control_catalog_id, '')::uuid;
+			  END IF;
+			END $$;
 		`).Error; err != nil {
 			return err
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catalog-scoped control resolution when an SSP is linked to profiles, including bulk-apply behavior
  * Better multi-requirement handling with per-requirement suggestion evaluation

* **Bug Fixes**
  * Prevented applying a suggestion for one requirement from removing suggestions for another
  * Reuse of existing system components when applying the same component to additional requirements

* **Tests**
  * Expanded integration and unit tests covering scoped resolution, ambiguity, and apply paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->