### PR TITLE
feat(authz): central authorization layer — PDP interface, manifest, builtin driver (BCH-1313)

### DIFF
--- a/internal/api/handler/api.go
+++ b/internal/api/handler/api.go
@@ -41,6 +41,11 @@ func RegisterHandlers(server *api.Server, logger *zap.SugaredLogger, db *gorm.DB
 		services.EvidenceService = evidencesvc.NewEvidenceService(db, logger, config, services.RiskEnqueuer)
 	}
 
+	// Central authorization PEP. Admin routes continue to go through
+	// middleware.RequireAdminGroups (itself now backed by this PEP); routes
+	// migrated onto Authorize() in this phase use it directly.
+	authorizer := middleware.NewAuthorizerFromConfig(db, config, logger)
+
 	healthHandler := NewHealthHandler(logger, db)
 	healthHandler.Register(server.API().Group("/health"))
 
@@ -60,6 +65,7 @@ func RegisterHandlers(server *api.Server, logger *zap.SugaredLogger, db *gorm.DB
 	evidenceHandler.RegisterCreate(
 		evidenceGroup,
 		middleware.OptionalUserOrAgentJWTMiddleware(db, config.JWTPublicKey, !config.StrictDisablePublicAgentEndpoints),
+		authorizer.Authorize("evidence", "create", middleware.WithPublicAccess(!config.StrictDisablePublicAgentEndpoints)),
 	)
 	evidenceHandler.RegisterReadRoutes(evidenceGroup)
 	evidenceSignatureGroup := server.API().Group("/evidence")

--- a/internal/api/middleware/admin.go
+++ b/internal/api/middleware/admin.go
@@ -1,14 +1,8 @@
 package middleware
 
 import (
-	"errors"
-	"net/http"
-	"strings"
-
-	"github.com/compliance-framework/api/internal/authn"
+	"github.com/compliance-framework/api/internal/authz"
 	"github.com/compliance-framework/api/internal/config"
-	"github.com/compliance-framework/api/internal/service/relational"
-	"github.com/compliance-framework/api/internal/service/sso"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
@@ -16,73 +10,12 @@ import (
 
 // RequireAdminGroups enforces that SSO-authenticated users belong to the provider's configured
 // admin groups. Password-based logins bypass this middleware (treated as super admins).
+//
+// It is now a thin wrapper over the central authorization PEP: it builds an
+// Authorizer for the configured driver and enforces the "admin" resource. The
+// builtin driver reproduces this exact rule (see internal/authz). New routes
+// should construct one Authorizer via NewAuthorizerFromConfig and call
+// Authorize("admin", ...) directly rather than using this helper.
 func RequireAdminGroups(db *gorm.DB, cfg *config.Config, logger *zap.SugaredLogger) echo.MiddlewareFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			claims, ok := c.Get("user").(*authn.UserClaims)
-			if !ok || claims == nil {
-				return echo.NewHTTPError(http.StatusUnauthorized, "missing authentication claims")
-			}
-
-			var user relational.User
-			if err := db.Where("email = ?", claims.Subject).First(&user).Error; err != nil {
-				if errors.Is(err, gorm.ErrRecordNotFound) {
-					return echo.NewHTTPError(http.StatusForbidden, "user not found")
-				}
-				logger.Errorw("Failed to load user for admin enforcement", "email", claims.Subject, "error", err)
-				return echo.NewHTTPError(http.StatusInternalServerError, "failed to load user")
-			}
-
-			if strings.ToLower(user.AuthMethod) != "sso" {
-				// Password (or other non-SSO) users bypass group enforcement.
-				return next(c)
-			}
-			if cfg == nil || cfg.SSO == nil || !cfg.SSO.Enabled {
-				// Without SSO config we cannot enforce provider-based admin groups; allow request.
-				return next(c)
-			}
-
-			var link relational.SSOUserLink
-			if err := db.
-				Where("user_id = ? AND deleted_at IS NULL", user.ID.String()).
-				Order("last_sync DESC").
-				First(&link).Error; err != nil {
-				logger.Warnw("Missing SSO link for admin enforcement", "userID", user.ID.String(), "error", err)
-				return echo.NewHTTPError(http.StatusForbidden, "missing SSO link for user")
-			}
-
-			providerConfig := cfg.SSO.GetProvider(link.Provider)
-			if providerConfig == nil {
-				logger.Warnw("Provider config not found for admin enforcement", "provider", link.Provider)
-				// SSO IS enabled and this provider is unknown - we should fail.
-				return echo.NewHTTPError(http.StatusForbidden, "provider configuration not found")
-			}
-
-			if len(providerConfig.RequiredAdminGroups) == 0 {
-				return next(c)
-			}
-
-			groupSet := make(map[string]struct{})
-			for _, g := range sso.DeserializeStringArray(link.Groups) {
-				normalized := strings.TrimSpace(strings.ToLower(g))
-				if normalized != "" {
-					groupSet[normalized] = struct{}{}
-				}
-			}
-
-			for _, required := range providerConfig.RequiredAdminGroups {
-				normalized := strings.TrimSpace(strings.ToLower(required))
-				if _, ok := groupSet[normalized]; !ok {
-					logger.Warnw("User missing required admin group",
-						"userID", user.ID.String(),
-						"requiredGroup", required,
-						"provider", link.Provider,
-					)
-					return echo.NewHTTPError(http.StatusForbidden, "missing required admin groups")
-				}
-			}
-
-			return next(c)
-		}
-	}
+	return NewAuthorizerFromConfig(db, cfg, logger).Authorize(authz.ResourceAdmin, "manage")
 }

--- a/internal/api/middleware/authorize.go
+++ b/internal/api/middleware/authorize.go
@@ -1,0 +1,177 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/compliance-framework/api/internal/authn"
+	"github.com/compliance-framework/api/internal/authz"
+	"github.com/compliance-framework/api/internal/config"
+	"github.com/labstack/echo/v4"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// Authorizer is CCF's Policy Enforcement Point (PEP). It builds an authz.Subject
+// from the request's authenticated claims, asks the configured PDP for a
+// decision, and enforces it. It supplies facts only and holds no policy logic.
+//
+// Enforcement outcomes:
+//   - allow                       -> the request proceeds;
+//   - explicit deny               -> 403 (the PDP reason is logged, never echoed);
+//   - evaluator error, fail open  -> the request proceeds;
+//   - evaluator error, fail closed-> 500 (an evaluator error is an internal
+//     failure; 403 is reserved for an explicit policy deny).
+type Authorizer struct {
+	pdp      authz.PDP
+	logger   *zap.SugaredLogger
+	failMode authz.FailMode
+}
+
+// NewAuthorizer builds an Authorizer around an already-constructed PDP.
+func NewAuthorizer(pdp authz.PDP, logger *zap.SugaredLogger, failMode authz.FailMode) *Authorizer {
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
+	return &Authorizer{pdp: pdp, logger: logger, failMode: failMode}
+}
+
+// NewAuthorizerFromConfig constructs an Authorizer for the driver named in
+// cfg.AuthZ (defaulting to the builtin engine, failing closed) using the
+// embedded authorization manifest. A misconfigured driver or an unloadable
+// manifest is fatal: the server must not start enforcing with the wrong engine.
+func NewAuthorizerFromConfig(db *gorm.DB, cfg *config.Config, logger *zap.SugaredLogger) *Authorizer {
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
+
+	driver := config.AuthZDriverBuiltin
+	failMode := authz.FailClosed
+	if cfg != nil && cfg.AuthZ != nil {
+		if cfg.AuthZ.Driver != "" {
+			driver = cfg.AuthZ.Driver
+		}
+		failMode = authz.ParseFailMode(cfg.AuthZ.FailMode)
+	}
+
+	manifest, err := authz.DefaultManifest()
+	if err != nil {
+		logger.Fatalw("authz: failed to load authorization manifest", "error", err)
+	}
+
+	pdp, err := authz.Open(driver, authz.Options{
+		DB:       db,
+		Config:   cfg,
+		Logger:   logger,
+		Manifest: manifest,
+	})
+	if err != nil {
+		logger.Fatalw("authz: failed to initialize authorization driver", "driver", driver, "error", err)
+	}
+
+	logger.Debugw("authz: enforcement initialized", "driver", driver, "failMode", string(failMode))
+	return NewAuthorizer(pdp, logger, failMode)
+}
+
+type authorizeOptions struct {
+	allowPublic     bool
+	resourceIDParam string
+}
+
+// AuthorizeOption customizes a single Authorize middleware.
+type AuthorizeOption func(*authorizeOptions)
+
+// WithPublicAccess lets anonymous requests reach the PDP with the allow_public
+// fact set, for routes that opt into public access (e.g. public agent ingest).
+func WithPublicAccess(allow bool) AuthorizeOption {
+	return func(o *authorizeOptions) { o.allowPublic = allow }
+}
+
+// WithResourceIDParam names the route param holding the resource instance id
+// (e.g. "id"); its value is passed to the PDP as Resource.ID.
+func WithResourceIDParam(name string) AuthorizeOption {
+	return func(o *authorizeOptions) { o.resourceIDParam = name }
+}
+
+// Authorize returns middleware that enforces (resource, action) for the request
+// through the configured PDP. It must run after an authentication middleware has
+// populated the request context with user or agent claims.
+func (a *Authorizer) Authorize(resource, action string, opts ...AuthorizeOption) echo.MiddlewareFunc {
+	var o authorizeOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if c.Request().Method == http.MethodOptions {
+				// CORS preflight is handled by the global CORS middleware; never
+				// gate it here.
+				return next(c)
+			}
+
+			subject := subjectFromContext(c)
+
+			res := authz.Resource{Type: resource}
+			if o.resourceIDParam != "" {
+				res.ID = c.Param(o.resourceIDParam)
+			}
+
+			reqCtx := map[string]any{
+				"allow_public": o.allowPublic,
+				"method":       c.Request().Method,
+			}
+
+			if a.pdp == nil {
+				a.logger.Errorw("authz: no PDP configured; denying", "resource", resource, "action", action)
+				return echo.NewHTTPError(http.StatusForbidden, "forbidden")
+			}
+
+			decision, err := a.pdp.Evaluate(c.Request().Context(), subject, action, res, reqCtx)
+			if err != nil {
+				a.logger.Errorw("authz: evaluation error",
+					"resource", resource, "action", action, "subjectType", subject.Type, "error", err)
+				if a.failMode == authz.FailOpen {
+					return next(c)
+				}
+				return echo.NewHTTPError(http.StatusInternalServerError, "authorization check failed")
+			}
+
+			if !decision.Allow {
+				a.logger.Warnw("authz: request denied",
+					"resource", resource, "action", action,
+					"subjectType", subject.Type, "subjectID", subject.ID,
+					"reason", decision.Reason)
+				return echo.NewHTTPError(http.StatusForbidden, "forbidden")
+			}
+
+			return next(c)
+		}
+	}
+}
+
+// subjectFromContext builds an authz.Subject from the authenticated claims an
+// upstream authn middleware stored in the request context, or an anonymous
+// subject when none are present.
+func subjectFromContext(c echo.Context) authz.Subject {
+	if claims, ok := c.Get("user").(*authn.UserClaims); ok && claims != nil {
+		return authz.Subject{
+			Type: authz.SubjectUser,
+			ID:   claims.Subject,
+			Props: map[string]any{
+				"email": claims.Subject,
+			},
+		}
+	}
+	if claims, ok := c.Get("agent_claims").(*authn.AgentClaims); ok && claims != nil {
+		return authz.Subject{
+			Type: authz.SubjectAgent,
+			ID:   claims.Subject,
+			Props: map[string]any{
+				"service_account": claims.Subject,
+				"agent_id":        claims.AgentID,
+				"auth_method":     claims.AuthMethod,
+			},
+		}
+	}
+	return authz.Subject{Type: authz.SubjectAnonymous}
+}

--- a/internal/api/middleware/authorize_test.go
+++ b/internal/api/middleware/authorize_test.go
@@ -1,0 +1,159 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/compliance-framework/api/internal/authn"
+	"github.com/compliance-framework/api/internal/authz"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type stubPDP struct {
+	decision    authz.Decision
+	err         error
+	called      bool
+	gotSubject  authz.Subject
+	gotAction   string
+	gotResource authz.Resource
+	gotCtx      map[string]any
+}
+
+func (s *stubPDP) Evaluate(_ context.Context, subj authz.Subject, action string, res authz.Resource, reqCtx map[string]any) (authz.Decision, error) {
+	s.called = true
+	s.gotSubject = subj
+	s.gotAction = action
+	s.gotResource = res
+	s.gotCtx = reqCtx
+	return s.decision, s.err
+}
+
+func (s *stubPDP) Evaluations(context.Context, []authz.EvalRequest) ([]authz.Decision, error) {
+	return nil, nil
+}
+
+func newTestContext(method string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(method, "/api/evidence", nil)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+func runAuthorize(t *testing.T, a *Authorizer, c echo.Context, opts ...AuthorizeOption) (bool, error) {
+	t.Helper()
+	nextCalled := false
+	h := a.Authorize("evidence", "create", opts...)(func(c echo.Context) error {
+		nextCalled = true
+		return c.NoContent(http.StatusOK)
+	})
+	return nextCalled, h(c)
+}
+
+func httpStatus(t *testing.T, err error) int {
+	t.Helper()
+	he := &echo.HTTPError{}
+	require.Truef(t, errors.As(err, &he), "expected *echo.HTTPError, got %T", err)
+	return he.Code
+}
+
+func TestAuthorize_Allow(t *testing.T) {
+	a := NewAuthorizer(&stubPDP{decision: authz.Decision{Allow: true}}, zap.NewNop().Sugar(), authz.FailClosed)
+	c, rec := newTestContext(http.MethodPost)
+	called, err := runAuthorize(t, a, c)
+	require.NoError(t, err)
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestAuthorize_Deny(t *testing.T) {
+	a := NewAuthorizer(&stubPDP{decision: authz.Decision{Allow: false, Reason: "nope"}}, zap.NewNop().Sugar(), authz.FailClosed)
+	c, _ := newTestContext(http.MethodPost)
+	called, err := runAuthorize(t, a, c)
+	require.False(t, called)
+	require.Equal(t, http.StatusForbidden, httpStatus(t, err))
+}
+
+func TestAuthorize_ErrorFailClosed(t *testing.T) {
+	a := NewAuthorizer(&stubPDP{err: errors.New("boom")}, zap.NewNop().Sugar(), authz.FailClosed)
+	c, _ := newTestContext(http.MethodPost)
+	called, err := runAuthorize(t, a, c)
+	require.False(t, called)
+	require.Equal(t, http.StatusInternalServerError, httpStatus(t, err))
+}
+
+func TestAuthorize_ErrorFailOpen(t *testing.T) {
+	a := NewAuthorizer(&stubPDP{err: errors.New("boom")}, zap.NewNop().Sugar(), authz.FailOpen)
+	c, rec := newTestContext(http.MethodPost)
+	called, err := runAuthorize(t, a, c)
+	require.NoError(t, err)
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestAuthorize_OptionsSkipsPDP(t *testing.T) {
+	stub := &stubPDP{decision: authz.Decision{Allow: false}}
+	a := NewAuthorizer(stub, zap.NewNop().Sugar(), authz.FailClosed)
+	c, _ := newTestContext(http.MethodOptions)
+	called, err := runAuthorize(t, a, c)
+	require.NoError(t, err)
+	require.True(t, called)
+	require.False(t, stub.called, "PDP must not be consulted for CORS preflight")
+}
+
+func TestAuthorize_NilPDPDenies(t *testing.T) {
+	a := NewAuthorizer(nil, zap.NewNop().Sugar(), authz.FailClosed)
+	c, _ := newTestContext(http.MethodPost)
+	called, err := runAuthorize(t, a, c)
+	require.False(t, called)
+	require.Equal(t, http.StatusForbidden, httpStatus(t, err))
+}
+
+func TestAuthorize_BuildsUserSubject(t *testing.T) {
+	stub := &stubPDP{decision: authz.Decision{Allow: true}}
+	a := NewAuthorizer(stub, zap.NewNop().Sugar(), authz.FailClosed)
+	c, _ := newTestContext(http.MethodPost)
+	c.Set("user", &authn.UserClaims{RegisteredClaims: jwt.RegisteredClaims{Subject: "alice@example.com"}})
+	_, err := runAuthorize(t, a, c)
+	require.NoError(t, err)
+	require.Equal(t, authz.SubjectUser, stub.gotSubject.Type)
+	require.Equal(t, "alice@example.com", stub.gotSubject.ID)
+	require.Equal(t, "alice@example.com", stub.gotSubject.Props["email"])
+}
+
+func TestAuthorize_BuildsAgentSubject(t *testing.T) {
+	stub := &stubPDP{decision: authz.Decision{Allow: true}}
+	a := NewAuthorizer(stub, zap.NewNop().Sugar(), authz.FailClosed)
+	c, _ := newTestContext(http.MethodPost)
+	c.Set("agent_claims", &authn.AgentClaims{RegisteredClaims: jwt.RegisteredClaims{Subject: "client-1"}, AgentID: "agent-1"})
+	_, err := runAuthorize(t, a, c)
+	require.NoError(t, err)
+	require.Equal(t, authz.SubjectAgent, stub.gotSubject.Type)
+	require.Equal(t, "client-1", stub.gotSubject.ID)
+	require.Equal(t, "agent-1", stub.gotSubject.Props["agent_id"])
+}
+
+func TestAuthorize_AnonymousSubject(t *testing.T) {
+	stub := &stubPDP{decision: authz.Decision{Allow: true}}
+	a := NewAuthorizer(stub, zap.NewNop().Sugar(), authz.FailClosed)
+	c, _ := newTestContext(http.MethodPost)
+	_, err := runAuthorize(t, a, c)
+	require.NoError(t, err)
+	require.Equal(t, authz.SubjectAnonymous, stub.gotSubject.Type)
+}
+
+func TestAuthorize_PassesContextAndResource(t *testing.T) {
+	stub := &stubPDP{decision: authz.Decision{Allow: true}}
+	a := NewAuthorizer(stub, zap.NewNop().Sugar(), authz.FailClosed)
+	c, _ := newTestContext(http.MethodPost)
+	_, err := runAuthorize(t, a, c, WithPublicAccess(true))
+	require.NoError(t, err)
+	require.Equal(t, true, stub.gotCtx["allow_public"])
+	require.Equal(t, "create", stub.gotAction)
+	require.Equal(t, "evidence", stub.gotResource.Type)
+}

--- a/internal/authz/builtin.go
+++ b/internal/authz/builtin.go
@@ -1,0 +1,174 @@
+package authz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/compliance-framework/api/internal/config"
+	"github.com/compliance-framework/api/internal/service/relational"
+	"github.com/compliance-framework/api/internal/service/sso"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// DriverBuiltin is the name of the default, in-process driver.
+const DriverBuiltin = "builtin"
+
+func init() {
+	Register(DriverBuiltin, newBuiltin)
+}
+
+// builtinPDP reproduces CCF's pre-authz access rules with zero behavior change:
+//   - admin resources require the SSO admin groups previously enforced by
+//     middleware.RequireAdminGroups;
+//   - every other resource is allowed for any authenticated subject (and for
+//     anonymous requests only where the route explicitly permits public access,
+//     e.g. agent ingest with public endpoints enabled).
+//
+// As the in-process default it self-fetches the facts the admin check needs
+// (user record, SSO link, provider config) via the DB and config it is built
+// with. Exporting those facts into the evaluation tuple for remote drivers is a
+// later-phase concern tracked under BCH-1319.
+type builtinPDP struct {
+	db     *gorm.DB
+	cfg    *config.Config
+	logger *zap.SugaredLogger
+}
+
+func newBuiltin(opts Options) (PDP, error) {
+	if opts.DB == nil {
+		return nil, errors.New("authz: builtin driver requires a database handle")
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
+	return &builtinPDP{db: opts.DB, cfg: opts.Config, logger: logger}, nil
+}
+
+// ResourceAdmin is the resource type whose actions require SSO admin groups.
+const ResourceAdmin = "admin"
+
+// ctxKeyAllowPublic, when set true in the request context, lets an anonymous
+// subject through (mirroring routes that opt into public access).
+const ctxKeyAllowPublic = "allow_public"
+
+func (p *builtinPDP) Evaluate(ctx context.Context, s Subject, action string, r Resource, reqCtx map[string]any) (Decision, error) {
+	if r.Type == ResourceAdmin {
+		return p.evaluateAdmin(s)
+	}
+
+	// Default rule: authenticated subjects are allowed.
+	if isAuthenticated(s) {
+		return Decision{Allow: true, Reason: "authenticated subject"}, nil
+	}
+	// Anonymous requests are allowed only where the route opts into public
+	// access (e.g. public agent ingest).
+	if allowPublic, _ := reqCtx[ctxKeyAllowPublic].(bool); allowPublic {
+		return Decision{Allow: true, Reason: "public access permitted for route"}, nil
+	}
+	return Decision{Allow: false, Reason: "subject is not authenticated"}, nil
+}
+
+func (p *builtinPDP) Evaluations(ctx context.Context, reqs []EvalRequest) ([]Decision, error) {
+	decisions := make([]Decision, len(reqs))
+	for i, req := range reqs {
+		d, err := p.Evaluate(ctx, req.Subject, req.Action, req.Resource, req.Context)
+		if err != nil {
+			return nil, err
+		}
+		decisions[i] = d
+	}
+	return decisions, nil
+}
+
+// evaluateAdmin mirrors middleware.RequireAdminGroups exactly so admin routes
+// keep their existing allow/deny outcomes. A returned error signals an internal
+// failure (e.g. DB read error) which the PEP surfaces as 500 — matching the
+// prior behavior where loading the user could fail with 500. Every explicit
+// deny is returned as Decision{Allow:false} (mapped to 403 by the PEP).
+func (p *builtinPDP) evaluateAdmin(s Subject) (Decision, error) {
+	email := subjectEmail(s)
+	if email == "" {
+		// Unreachable in practice: admin routes run JWT authn first, which
+		// rejects unauthenticated requests with 401 before the PEP is reached.
+		return Decision{Allow: false, Reason: "missing authentication claims"}, nil
+	}
+
+	var user relational.User
+	if err := p.db.Where("email = ?", email).First(&user).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return Decision{Allow: false, Reason: "user not found"}, nil
+		}
+		p.logger.Errorw("Failed to load user for admin enforcement", "email", email, "error", err)
+		return Decision{}, fmt.Errorf("load user for admin enforcement: %w", err)
+	}
+
+	if strings.ToLower(user.AuthMethod) != "sso" {
+		// Password (or other non-SSO) users bypass group enforcement.
+		return Decision{Allow: true, Reason: "non-sso user bypasses admin groups"}, nil
+	}
+	if p.cfg == nil || p.cfg.SSO == nil || !p.cfg.SSO.Enabled {
+		// Without SSO config we cannot enforce provider-based admin groups.
+		return Decision{Allow: true, Reason: "sso disabled"}, nil
+	}
+
+	var link relational.SSOUserLink
+	if err := p.db.
+		Where("user_id = ? AND deleted_at IS NULL", user.ID.String()).
+		Order("last_sync DESC").
+		First(&link).Error; err != nil {
+		p.logger.Warnw("Missing SSO link for admin enforcement", "userID", user.ID.String(), "error", err)
+		return Decision{Allow: false, Reason: "missing SSO link for user"}, nil
+	}
+
+	providerConfig := p.cfg.SSO.GetProvider(link.Provider)
+	if providerConfig == nil {
+		p.logger.Warnw("Provider config not found for admin enforcement", "provider", link.Provider)
+		return Decision{Allow: false, Reason: "provider configuration not found"}, nil
+	}
+
+	if len(providerConfig.RequiredAdminGroups) == 0 {
+		return Decision{Allow: true, Reason: "provider requires no admin groups"}, nil
+	}
+
+	groupSet := make(map[string]struct{})
+	for _, g := range sso.DeserializeStringArray(link.Groups) {
+		normalized := strings.TrimSpace(strings.ToLower(g))
+		if normalized != "" {
+			groupSet[normalized] = struct{}{}
+		}
+	}
+
+	for _, required := range providerConfig.RequiredAdminGroups {
+		normalized := strings.TrimSpace(strings.ToLower(required))
+		if _, ok := groupSet[normalized]; !ok {
+			p.logger.Warnw("User missing required admin group",
+				"userID", user.ID.String(),
+				"requiredGroup", required,
+				"provider", link.Provider,
+			)
+			return Decision{Allow: false, Reason: "missing required admin groups"}, nil
+		}
+	}
+
+	return Decision{Allow: true, Reason: "admin groups satisfied"}, nil
+}
+
+func isAuthenticated(s Subject) bool {
+	return s.Type == SubjectUser || s.Type == SubjectAgent
+}
+
+// subjectEmail returns the user email for a user subject, preferring the
+// explicit email prop and falling back to the subject ID.
+func subjectEmail(s Subject) string {
+	if s.Type != SubjectUser {
+		return ""
+	}
+	if email, ok := s.Props["email"].(string); ok && email != "" {
+		return email
+	}
+	return s.ID
+}

--- a/internal/authz/builtin.go
+++ b/internal/authz/builtin.go
@@ -57,7 +57,7 @@ const ctxKeyAllowPublic = "allow_public"
 
 func (p *builtinPDP) Evaluate(ctx context.Context, s Subject, action string, r Resource, reqCtx map[string]any) (Decision, error) {
 	if r.Type == ResourceAdmin {
-		return p.evaluateAdmin(s)
+		return p.evaluateAdmin(ctx, s)
 	}
 
 	// Default rule: authenticated subjects are allowed.
@@ -89,7 +89,7 @@ func (p *builtinPDP) Evaluations(ctx context.Context, reqs []EvalRequest) ([]Dec
 // failure (e.g. DB read error) which the PEP surfaces as 500 — matching the
 // prior behavior where loading the user could fail with 500. Every explicit
 // deny is returned as Decision{Allow:false} (mapped to 403 by the PEP).
-func (p *builtinPDP) evaluateAdmin(s Subject) (Decision, error) {
+func (p *builtinPDP) evaluateAdmin(ctx context.Context, s Subject) (Decision, error) {
 	email := subjectEmail(s)
 	if email == "" {
 		// Unreachable in practice: admin routes run JWT authn first, which
@@ -98,7 +98,7 @@ func (p *builtinPDP) evaluateAdmin(s Subject) (Decision, error) {
 	}
 
 	var user relational.User
-	if err := p.db.Where("email = ?", email).First(&user).Error; err != nil {
+	if err := p.db.WithContext(ctx).Where("email = ?", email).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return Decision{Allow: false, Reason: "user not found"}, nil
 		}
@@ -116,7 +116,7 @@ func (p *builtinPDP) evaluateAdmin(s Subject) (Decision, error) {
 	}
 
 	var link relational.SSOUserLink
-	if err := p.db.
+	if err := p.db.WithContext(ctx).
 		Where("user_id = ? AND deleted_at IS NULL", user.ID.String()).
 		Order("last_sync DESC").
 		First(&link).Error; err != nil {

--- a/internal/authz/builtin_test.go
+++ b/internal/authz/builtin_test.go
@@ -1,0 +1,197 @@
+package authz
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/compliance-framework/api/internal/config"
+	"github.com/compliance-framework/api/internal/service/relational"
+	"github.com/compliance-framework/api/internal/service/sso"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&relational.User{}, &relational.SSOUserLink{}))
+	return db
+}
+
+func newBuiltinForTest(t *testing.T, db *gorm.DB, cfg *config.Config) PDP {
+	t.Helper()
+	pdp, err := Open(DriverBuiltin, Options{DB: db, Config: cfg, Logger: zap.NewNop().Sugar()})
+	require.NoError(t, err)
+	return pdp
+}
+
+func createUser(t *testing.T, db *gorm.DB, email, authMethod string) *relational.User {
+	t.Helper()
+	u := &relational.User{Email: email, AuthMethod: authMethod}
+	require.NoError(t, db.Create(u).Error)
+	return u
+}
+
+func createLink(t *testing.T, db *gorm.DB, user *relational.User, provider string, groups []string) {
+	t.Helper()
+	link := &relational.SSOUserLink{
+		UserID:     user.ID.String(),
+		Provider:   provider,
+		ExternalID: "ext-" + provider,
+		Email:      user.Email,
+		Groups:     sso.SerializeStringArray(groups),
+		LastSync:   time.Now().Add(-time.Hour),
+	}
+	require.NoError(t, db.Create(link).Error)
+}
+
+func ssoConfig(provider string, requiredAdminGroups []string) *config.Config {
+	return &config.Config{
+		SSO: &config.SSOConfig{
+			Enabled: true,
+			Providers: map[string]config.SSOProviderConfig{
+				provider: {Name: provider, RequiredAdminGroups: requiredAdminGroups},
+			},
+		},
+	}
+}
+
+// TestBuiltin_DefaultResource covers the "authenticated = allowed" rule plus the
+// public-access exception used by routes like agent ingest.
+func TestBuiltin_DefaultResource(t *testing.T) {
+	pdp := newBuiltinForTest(t, newTestDB(t), nil)
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		subject Subject
+		reqCtx  map[string]any
+		allow   bool
+	}{
+		{"authenticated user", Subject{Type: SubjectUser, ID: "u@example.com"}, nil, true},
+		{"authenticated agent", Subject{Type: SubjectAgent, ID: "agent-1"}, nil, true},
+		{"anonymous without public", Subject{Type: SubjectAnonymous}, nil, false},
+		{"anonymous with public", Subject{Type: SubjectAnonymous}, map[string]any{ctxKeyAllowPublic: true}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := pdp.Evaluate(ctx, tc.subject, "create", Resource{Type: "evidence"}, tc.reqCtx)
+			require.NoError(t, err)
+			require.Equal(t, tc.allow, d.Allow, "reason: %s", d.Reason)
+		})
+	}
+}
+
+// TestBuiltin_Admin exercises every branch of the migrated RequireAdminGroups
+// logic, asserting identical allow/deny outcomes.
+func TestBuiltin_Admin(t *testing.T) {
+	ctx := context.Background()
+	adminResource := Resource{Type: ResourceAdmin}
+
+	t.Run("user not found denies", func(t *testing.T) {
+		pdp := newBuiltinForTest(t, newTestDB(t), ssoConfig("google", []string{"ccf-admins"}))
+		d, err := pdp.Evaluate(ctx, Subject{Type: SubjectUser, ID: "ghost@example.com"}, "manage", adminResource, nil)
+		require.NoError(t, err)
+		require.False(t, d.Allow)
+	})
+
+	t.Run("non-sso user bypasses", func(t *testing.T) {
+		db := newTestDB(t)
+		createUser(t, db, "pw@example.com", "password")
+		pdp := newBuiltinForTest(t, db, ssoConfig("google", []string{"ccf-admins"}))
+		d, err := pdp.Evaluate(ctx, Subject{Type: SubjectUser, ID: "pw@example.com"}, "manage", adminResource, nil)
+		require.NoError(t, err)
+		require.True(t, d.Allow)
+	})
+
+	t.Run("sso disabled allows", func(t *testing.T) {
+		db := newTestDB(t)
+		createUser(t, db, "sso@example.com", "sso")
+		pdp := newBuiltinForTest(t, db, &config.Config{SSO: nil})
+		d, err := pdp.Evaluate(ctx, Subject{Type: SubjectUser, ID: "sso@example.com"}, "manage", adminResource, nil)
+		require.NoError(t, err)
+		require.True(t, d.Allow)
+	})
+
+	t.Run("missing sso link denies", func(t *testing.T) {
+		db := newTestDB(t)
+		createUser(t, db, "sso@example.com", "sso")
+		pdp := newBuiltinForTest(t, db, ssoConfig("google", []string{"ccf-admins"}))
+		d, err := pdp.Evaluate(ctx, Subject{Type: SubjectUser, ID: "sso@example.com"}, "manage", adminResource, nil)
+		require.NoError(t, err)
+		require.False(t, d.Allow)
+	})
+
+	t.Run("unknown provider denies", func(t *testing.T) {
+		db := newTestDB(t)
+		u := createUser(t, db, "sso@example.com", "sso")
+		createLink(t, db, u, "okta", []string{"ccf-admins"})
+		pdp := newBuiltinForTest(t, db, ssoConfig("google", []string{"ccf-admins"}))
+		d, err := pdp.Evaluate(ctx, Subject{Type: SubjectUser, ID: "sso@example.com"}, "manage", adminResource, nil)
+		require.NoError(t, err)
+		require.False(t, d.Allow)
+	})
+
+	t.Run("provider without required groups allows", func(t *testing.T) {
+		db := newTestDB(t)
+		u := createUser(t, db, "sso@example.com", "sso")
+		createLink(t, db, u, "google", nil)
+		pdp := newBuiltinForTest(t, db, ssoConfig("google", nil))
+		d, err := pdp.Evaluate(ctx, Subject{Type: SubjectUser, ID: "sso@example.com"}, "manage", adminResource, nil)
+		require.NoError(t, err)
+		require.True(t, d.Allow)
+	})
+
+	t.Run("required group present allows", func(t *testing.T) {
+		db := newTestDB(t)
+		u := createUser(t, db, "sso@example.com", "sso")
+		createLink(t, db, u, "google", []string{"ccf-admins", "other"})
+		pdp := newBuiltinForTest(t, db, ssoConfig("google", []string{"ccf-admins"}))
+		d, err := pdp.Evaluate(ctx, Subject{Type: SubjectUser, ID: "sso@example.com"}, "manage", adminResource, nil)
+		require.NoError(t, err)
+		require.True(t, d.Allow)
+	})
+
+	t.Run("required group missing denies", func(t *testing.T) {
+		db := newTestDB(t)
+		u := createUser(t, db, "sso@example.com", "sso")
+		createLink(t, db, u, "google", []string{"other"})
+		pdp := newBuiltinForTest(t, db, ssoConfig("google", []string{"ccf-admins"}))
+		d, err := pdp.Evaluate(ctx, Subject{Type: SubjectUser, ID: "sso@example.com"}, "manage", adminResource, nil)
+		require.NoError(t, err)
+		require.False(t, d.Allow)
+	})
+
+	t.Run("group match is case insensitive", func(t *testing.T) {
+		db := newTestDB(t)
+		u := createUser(t, db, "sso@example.com", "sso")
+		createLink(t, db, u, "google", []string{"CCF-Admins"})
+		pdp := newBuiltinForTest(t, db, ssoConfig("google", []string{"ccf-admins"}))
+		d, err := pdp.Evaluate(ctx, Subject{Type: SubjectUser, ID: "sso@example.com"}, "manage", adminResource, nil)
+		require.NoError(t, err)
+		require.True(t, d.Allow)
+	})
+}
+
+func TestBuiltin_RequiresDB(t *testing.T) {
+	_, err := Open(DriverBuiltin, Options{Logger: zap.NewNop().Sugar()})
+	require.Error(t, err)
+}
+
+func TestBuiltin_Evaluations(t *testing.T) {
+	pdp := newBuiltinForTest(t, newTestDB(t), nil)
+	decisions, err := pdp.Evaluations(context.Background(), []EvalRequest{
+		{Subject: Subject{Type: SubjectUser, ID: "u@example.com"}, Action: "create", Resource: Resource{Type: "evidence"}},
+		{Subject: Subject{Type: SubjectAnonymous}, Action: "create", Resource: Resource{Type: "evidence"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, decisions, 2)
+	require.True(t, decisions[0].Allow)
+	require.False(t, decisions[1].Allow)
+}

--- a/internal/authz/manifest.go
+++ b/internal/authz/manifest.go
@@ -1,0 +1,108 @@
+package authz
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// manifestYAML is the canonical authorization vocabulary, embedded so a valid
+// manifest is always available regardless of deployment layout. Operators may
+// override it with an external file (see LoadManifest / authz_manifest_path).
+//
+//go:embed manifest.yaml
+var manifestYAML []byte
+
+// Manifest is CCF's engine-neutral authorization vocabulary: the resources,
+// actions and default roles operators can write policies against. It is treated
+// as a public API surface — renaming an action or attribute is a breaking
+// change for every customer policy set.
+type Manifest struct {
+	SchemaVersion int                    `yaml:"schemaVersion"`
+	Subjects      map[string]SubjectDef  `yaml:"subjects"`
+	Resources     map[string]ResourceDef `yaml:"resources"`
+	// Roles are suggested defaults: role -> resource -> actions. Operators may
+	// override or extend them in their PAP.
+	Roles map[string]map[string][]string `yaml:"roles"`
+}
+
+// SubjectDef declares the attributes a subject type exports into the evaluation
+// tuple.
+type SubjectDef struct {
+	Attributes map[string]string `yaml:"attributes"`
+}
+
+// ResourceDef declares a resource's allowed actions and the attributes it
+// exports. Per BCH-1319 the attribute surface is intentionally minimal in this
+// phase.
+type ResourceDef struct {
+	Actions    []string          `yaml:"actions"`
+	Attributes map[string]string `yaml:"attributes"`
+}
+
+// ParseManifest parses and validates a manifest from YAML bytes.
+func ParseManifest(data []byte) (*Manifest, error) {
+	var m Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("authz: parse manifest: %w", err)
+	}
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// LoadManifest reads and validates a manifest from a file path.
+func LoadManifest(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("authz: read manifest %q: %w", path, err)
+	}
+	return ParseManifest(data)
+}
+
+// DefaultManifest returns the embedded canonical manifest.
+func DefaultManifest() (*Manifest, error) {
+	return ParseManifest(manifestYAML)
+}
+
+// Validate checks the manifest is structurally sound: a positive schema version
+// and at least one resource, each with at least one action.
+func (m *Manifest) Validate() error {
+	if m == nil {
+		return fmt.Errorf("authz: nil manifest")
+	}
+	if m.SchemaVersion <= 0 {
+		return fmt.Errorf("authz: manifest schemaVersion must be > 0, got %d", m.SchemaVersion)
+	}
+	if len(m.Resources) == 0 {
+		return fmt.Errorf("authz: manifest declares no resources")
+	}
+	for name, r := range m.Resources {
+		if len(r.Actions) == 0 {
+			return fmt.Errorf("authz: resource %q declares no actions", name)
+		}
+	}
+	return nil
+}
+
+// HasAction reports whether the manifest declares action on resource. It is a
+// helper for drivers that wish to validate requested (resource, action) pairs
+// against the vocabulary; the builtin driver does not gate on it in Phase 1.
+func (m *Manifest) HasAction(resource, action string) bool {
+	if m == nil {
+		return false
+	}
+	r, ok := m.Resources[resource]
+	if !ok {
+		return false
+	}
+	for _, a := range r.Actions {
+		if a == action {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/authz/manifest.yaml
+++ b/internal/authz/manifest.yaml
@@ -1,0 +1,34 @@
+# CCF authorization vocabulary — engine-neutral declaration of the resources,
+# actions and default roles that operator policies are written against.
+#
+# This file is treated as a PUBLIC API surface: renaming an action or attribute
+# is a breaking change for every customer policy set (see the "CCF Pluggable
+# Authorization — Design Plan").
+#
+# Phase 1 (BCH-1313) scope: only the vocabulary for the routes migrated onto the
+# Authorize() PEP — evidence and admin. The per-resource evaluation *attribute*
+# surface is intentionally minimal/provisional here; the authoritative attribute
+# design is gated on BCH-1319. Do not grow the attribute surface ad hoc.
+schemaVersion: 1
+
+subjects:
+  user:
+    attributes:
+      email: string
+      groups: set<string>
+      auth_method: string
+  agent:
+    attributes:
+      service_account: string
+
+resources:
+  evidence:
+    actions: [create, read]
+    attributes:
+      labels: set<string>   # provisional — see BCH-1319
+  admin:
+    actions: [manage]
+
+roles:   # suggested defaults — operators may override / extend in their PAP
+  admin:
+    "*": ["*"]

--- a/internal/authz/manifest_test.go
+++ b/internal/authz/manifest_test.go
@@ -1,0 +1,67 @@
+package authz
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultManifest(t *testing.T) {
+	m, err := DefaultManifest()
+	require.NoError(t, err)
+	require.Equal(t, 1, m.SchemaVersion)
+	require.Contains(t, m.Resources, "evidence")
+	require.Contains(t, m.Resources, "admin")
+	require.True(t, m.HasAction("evidence", "create"))
+	require.True(t, m.HasAction("admin", "manage"))
+	require.False(t, m.HasAction("evidence", "delete"))
+	require.False(t, m.HasAction("unknown", "create"))
+}
+
+func TestParseManifest_Valid(t *testing.T) {
+	m, err := ParseManifest([]byte(`
+schemaVersion: 1
+resources:
+  evidence:
+    actions: [read, create]
+`))
+	require.NoError(t, err)
+	require.True(t, m.HasAction("evidence", "read"))
+}
+
+func TestParseManifest_InvalidYAML(t *testing.T) {
+	_, err := ParseManifest([]byte("schemaVersion: 1\nresources: [this is not a map"))
+	require.Error(t, err)
+}
+
+func TestManifest_Validate(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{"zero schema version", "schemaVersion: 0\nresources:\n  x:\n    actions: [a]\n"},
+		{"no resources", "schemaVersion: 1\n"},
+		{"resource without actions", "schemaVersion: 1\nresources:\n  x:\n    actions: []\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseManifest([]byte(tc.yaml))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestLoadManifest(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("schemaVersion: 1\nresources:\n  evidence:\n    actions: [read]\n"), 0o600))
+
+	m, err := LoadManifest(path)
+	require.NoError(t, err)
+	require.True(t, m.HasAction("evidence", "read"))
+
+	_, err = LoadManifest(filepath.Join(dir, "missing.yaml"))
+	require.Error(t, err)
+}

--- a/internal/authz/pdp.go
+++ b/internal/authz/pdp.go
@@ -1,0 +1,71 @@
+// Package authz is CCF's central authorization layer.
+//
+// It defines an engine-neutral Policy Decision Point (PDP) interface plus a
+// driver registry (mirroring database/sql) so the authorization engine is
+// pluggable: a built-in RBAC driver today, and embedded Cedar / OpenFGA /
+// Permit.io / any AuthZen-compliant PDP later. The HTTP enforcement point (PEP)
+// lives in internal/api/middleware and is the only thing that calls into a PDP.
+//
+// See the "CCF Pluggable Authorization — Design Plan" for the full model. This
+// package implements Phase 1: the interface, the manifest loader and the
+// builtin driver that reproduces CCF's current access rules with zero behavior
+// change.
+package authz
+
+import "context"
+
+// Subject types.
+const (
+	SubjectUser      = "user"
+	SubjectAgent     = "agent"
+	SubjectAnonymous = "anonymous"
+)
+
+// Subject is the actor a decision is made about — a user or an agent. Props
+// carries the facts the PEP has gathered about the subject (e.g. email, groups,
+// auth_method). Drivers must treat a missing prop as "unknown", never as a
+// grant.
+type Subject struct {
+	Type  string // "user", "agent" or "anonymous"
+	ID    string // stable identifier (user email / agent client id)
+	Props map[string]any
+}
+
+// Resource is the thing being acted upon. Type matches a resource declared in
+// the manifest (e.g. "evidence", "admin"). ID/Props are the instance and its
+// (provisional, see BCH-1319) attributes.
+type Resource struct {
+	Type  string
+	ID    string
+	Props map[string]any
+}
+
+// Decision is the result of an evaluation. Reason is for operator logs only and
+// must never be echoed verbatim to clients.
+type Decision struct {
+	Allow  bool
+	Reason string
+}
+
+// EvalRequest is a single (subject, action, resource, context) tuple, used by
+// the batch Evaluations form.
+type EvalRequest struct {
+	Subject  Subject
+	Action   string
+	Resource Resource
+	Context  map[string]any
+}
+
+// PDP is a Policy Decision Point: given a self-contained tuple it returns an
+// allow/deny decision. Implementations must be safe for concurrent use.
+type PDP interface {
+	// Evaluate decides whether subject s may perform action on resource r.
+	// reqCtx carries request-scoped facts that are neither subject nor
+	// resource attributes (e.g. whether the route permits public access).
+	Evaluate(ctx context.Context, s Subject, action string, r Resource, reqCtx map[string]any) (Decision, error)
+
+	// Evaluations is the batch form (AuthZen "evaluations"), used for list
+	// filtering and UI permission hints. The returned slice is positional:
+	// one Decision per request, in the same order.
+	Evaluations(ctx context.Context, reqs []EvalRequest) ([]Decision, error)
+}

--- a/internal/authz/registry.go
+++ b/internal/authz/registry.go
@@ -1,0 +1,92 @@
+package authz
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/compliance-framework/api/internal/config"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// FailMode controls what the PEP does when a PDP cannot return a decision
+// (error or timeout). It defaults to closed.
+type FailMode string
+
+const (
+	// FailClosed denies the request when the evaluator cannot decide.
+	FailClosed FailMode = "closed"
+	// FailOpen allows the request when the evaluator cannot decide.
+	FailOpen FailMode = "open"
+)
+
+// ParseFailMode maps a config string to a FailMode, defaulting to FailClosed
+// for empty or unrecognized values.
+func ParseFailMode(s string) FailMode {
+	if FailMode(s) == FailOpen {
+		return FailOpen
+	}
+	return FailClosed
+}
+
+// Options carries everything a driver factory might need. In-process drivers
+// (like builtin) use DB/Config; remote drivers use Settings (driver-specific
+// values from config such as endpoint or cache_ttl). Manifest is the loaded
+// authorization vocabulary. Drivers take only what they need, much like a
+// database driver parses only the parts of a DSN it understands.
+type Options struct {
+	DB       *gorm.DB
+	Config   *config.Config
+	Logger   *zap.SugaredLogger
+	Manifest *Manifest
+	Settings map[string]any
+}
+
+// Factory builds a PDP from Options.
+type Factory func(Options) (PDP, error)
+
+var (
+	driversMu sync.RWMutex
+	drivers   = map[string]Factory{}
+)
+
+// Register makes an authorization driver available by name. It mirrors
+// database/sql's driver registration and is intended to be called from a
+// driver's init(). It panics on a duplicate or nil registration.
+func Register(name string, factory Factory) {
+	driversMu.Lock()
+	defer driversMu.Unlock()
+	if factory == nil {
+		panic("authz: Register factory is nil")
+	}
+	if _, dup := drivers[name]; dup {
+		panic("authz: Register called twice for driver " + name)
+	}
+	drivers[name] = factory
+}
+
+// Drivers returns the names of the registered drivers, sorted.
+func Drivers() []string {
+	driversMu.RLock()
+	defer driversMu.RUnlock()
+	names := make([]string, 0, len(drivers))
+	for name := range drivers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Open constructs the PDP registered under name using opts. It returns an error
+// (rather than falling back) so a misconfigured authz.driver fails fast at
+// startup instead of silently changing the enforcement engine.
+func Open(name string, opts Options) (PDP, error) {
+	driversMu.RLock()
+	factory, ok := drivers[name]
+	driversMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("authz: unknown driver %q (registered: %v)", name, Drivers())
+	}
+	return factory(opts)
+}

--- a/internal/authz/registry_test.go
+++ b/internal/authz/registry_test.go
@@ -1,0 +1,49 @@
+package authz
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFailMode(t *testing.T) {
+	require.Equal(t, FailOpen, ParseFailMode("open"))
+	require.Equal(t, FailClosed, ParseFailMode("closed"))
+	require.Equal(t, FailClosed, ParseFailMode(""))
+	require.Equal(t, FailClosed, ParseFailMode("garbage"))
+}
+
+func TestDriversIncludesBuiltin(t *testing.T) {
+	require.Contains(t, Drivers(), DriverBuiltin)
+}
+
+func TestOpenUnknownDriver(t *testing.T) {
+	_, err := Open("does-not-exist", Options{})
+	require.Error(t, err)
+}
+
+func TestRegisterNilPanics(t *testing.T) {
+	require.Panics(t, func() { Register("authz-test-nil", nil) })
+}
+
+func TestRegisterDuplicatePanics(t *testing.T) {
+	factory := func(Options) (PDP, error) { return nil, nil }
+	Register("authz-test-dup", factory)
+	require.Panics(t, func() { Register("authz-test-dup", factory) })
+}
+
+func TestOpenRegisteredDriver(t *testing.T) {
+	want := &fakePDP{}
+	Register("authz-test-open", func(Options) (PDP, error) { return want, nil })
+	got, err := Open("authz-test-open", Options{})
+	require.NoError(t, err)
+	require.Same(t, want, got)
+}
+
+type fakePDP struct{}
+
+func (fakePDP) Evaluate(context.Context, Subject, string, Resource, map[string]any) (Decision, error) {
+	return Decision{Allow: true}, nil
+}
+func (fakePDP) Evaluations(context.Context, []EvalRequest) ([]Decision, error) { return nil, nil }

--- a/internal/config/authz.go
+++ b/internal/config/authz.go
@@ -1,0 +1,37 @@
+package config
+
+import "github.com/spf13/viper"
+
+// Authorization driver and fail-mode defaults. The defaults reproduce CCF's
+// existing behavior: the in-process builtin engine, failing closed.
+const (
+	AuthZDriverBuiltin = "builtin"
+	AuthZFailClosed    = "closed"
+	AuthZFailOpen      = "open"
+)
+
+// AuthZConfig holds the operator-facing authorization settings. The decision
+// engine itself is selected by Driver (see internal/authz drivers); FailMode
+// controls what the enforcement point does when the engine cannot decide.
+//
+// Configured via the flat Viper keys used elsewhere in this package:
+//
+//	authz_driver     (env CCF_AUTHZ_DRIVER)     default "builtin"
+//	authz_fail_mode  (env CCF_AUTHZ_FAIL_MODE)  default "closed"
+type AuthZConfig struct {
+	Driver   string
+	FailMode string
+}
+
+func loadAuthZConfig() *AuthZConfig {
+	driver := viper.GetString("authz_driver")
+	if driver == "" {
+		driver = AuthZDriverBuiltin
+	}
+	failMode := viper.GetString("authz_fail_mode")
+	if failMode != AuthZFailOpen {
+		// Anything other than an explicit "open" fails closed.
+		failMode = AuthZFailClosed
+	}
+	return &AuthZConfig{Driver: driver, FailMode: failMode}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	PprofEnabled                      bool   // Enable or disable pprof debugging server
 	PprofPort                         string // Port for pprof debugging server
 	StrictDisablePublicAgentEndpoints bool
+	AuthZ                             *AuthZConfig
 }
 
 func NewConfig(logger *zap.SugaredLogger) *Config {
@@ -233,6 +234,7 @@ func NewConfig(logger *zap.SugaredLogger) *Config {
 
 	pprofEnabled := viper.GetBool("pprof_enabled")
 	strictDisablePublicAgentEndpoints := viper.GetBool("strict_disable_public_agent_endpoints")
+	authzConfig := loadAuthZConfig()
 	pprofPort := viper.GetString("pprof_port")
 	if pprofPort == "" {
 		pprofPort = "6060"
@@ -270,6 +272,7 @@ func NewConfig(logger *zap.SugaredLogger) *Config {
 		PprofEnabled:                      pprofEnabled,
 		PprofPort:                         pprofPort,
 		StrictDisablePublicAgentEndpoints: strictDisablePublicAgentEndpoints,
+		AuthZ:                             authzConfig,
 	}
 
 }


### PR DESCRIPTION
## BCH-1313 — AuthZ Phase 1

Introduces CCF's central authorization layer behind one PEP middleware + a pluggable PDP driver interface, with **zero behavior change**. Existing access rules are unchanged; they are now expressed through the new layer.

Jira: https://container-solutions.atlassian.net/browse/BCH-1313
Design: [CCF Pluggable Authorization — Design Plan](https://container-solutions.atlassian.net/wiki/spaces/BP/pages/2575073282/CCF+Pluggable+Authorization+Design+Plan)

### What's in this PR
- **`internal/authz` package**: `PDP` interface (`Evaluate` + batch `Evaluations`), `Subject`/`Resource`/`Decision`/`EvalRequest` types, and a driver registry (`authz.Register`/`Open`) mirroring `database/sql`.
- **Manifest loader** + embedded `internal/authz/manifest.yaml` — engine-neutral vocabulary covering the migrated routes (evidence, admin). Attributes are intentionally minimal/provisional (the authoritative per-resource attribute surface is gated on **BCH-1319**).
- **`builtin` driver** reproducing today's rules exactly: authenticated ⇒ allowed; admin routes require the SSO admin groups previously enforced by `RequireAdminGroups`. As the in-process default it self-fetches the admin facts it needs (user row, SSO link, provider config).
- **`mw.Authorizer.Authorize(resource, action)` PEP middleware**: builds the subject from user/agent claims, calls the PDP, enforces the result. Deny → 403 (reason logged, never echoed); evaluator error honours `authz.fail_mode` (default closed → 500 for internal failures, preserving prior behavior).
- **Migrations**: `RequireAdminGroups` is now a thin wrapper over the PEP (`Authorize("admin","manage")`); the evidence-create route (`evidence_auth.go` / `OptionalUserOrAgentJWTMiddleware`) gains `Authorize("evidence","create")` while keeping its authentication semantics (401 for missing creds, 403 for bad agent keys) intact.
- **Config (Viper)**: `authz_driver` (`CCF_AUTHZ_DRIVER`, default `builtin`) and `authz_fail_mode` (`CCF_AUTHZ_FAIL_MODE`, default `closed`).

### Notable decisions (see `git notes show` / `lisa-design`)
- Authentication (401) and authorization (403) are kept as distinct concerns; `evidence_auth.go` stays the authn layer.
- The builtin admin check mirrors `RequireAdminGroups` branch-for-branch; only the user-load path distinguishes not-found (deny/403) from a DB error (500).
- The per-resource evaluation **attribute surface is deliberately not grown here** — that is the BCH-1319 design task.

### Testing
- New unit tests: builtin driver (every admin branch + authenticated/public), manifest loader/validation, registry, and the PEP middleware (allow/deny/fail-open/fail-closed/OPTIONS/subject-building).
- Regression: `go build ./...`, `go vet ./...`, full unit suite, and the **evidence**, **templates (admin)** and **workflow-import (admin)** integration suites all pass — confirming zero behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented a centralized authorization system enabling fine-grained access control across resources and actions.
  * Added configurable enforcement of admin group membership via identity provider integration.
  * Introduced ability to restrict or permit public access to specific endpoints through configuration.

* **Refactor**
  * Consolidated authorization middleware to use a unified policy-based enforcement model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->