### PR TITLE
BCH-1336: fix Satisfied marshalling bug + add Export CRUD on by-components

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -16556,7 +16556,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "put": {
                 "description": "Updates the scalar fields of an existing Export for a by-component within an implemented requirement. Provided and Responsibilities entries are managed via their own routes.",
@@ -16627,7 +16632,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "post": {
                 "description": "Creates the Export for a by-component within an implemented requirement. A by-component may have at most one Export.",
@@ -16704,7 +16714,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "delete": {
                 "description": "Deletes the Export (and its Provided/Responsibilities entries) for a by-component within an implemented requirement.",
@@ -16757,7 +16772,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided": {
@@ -16830,7 +16850,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided/{providedId}": {
@@ -16910,7 +16935,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "delete": {
                 "description": "Deletes an existing ProvidedControlImplementation entry under the Export of a by-component within an implemented requirement.",
@@ -16970,7 +17000,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities": {
@@ -17043,7 +17078,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId}": {
@@ -17123,7 +17163,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "delete": {
                 "description": "Deletes an existing ControlImplementationResponsibility entry under the Export of a by-component within an implemented requirement.",
@@ -17183,7 +17228,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements": {
@@ -17503,8 +17553,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "201": {
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ByComponent"
                         }
@@ -17744,7 +17794,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "put": {
                 "description": "Updates the scalar fields of an existing Export for a by-component within a statement. Provided and Responsibilities entries are managed via their own routes.",
@@ -17822,7 +17877,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "post": {
                 "description": "Creates the Export for a by-component within a statement. A by-component may have at most one Export.",
@@ -17906,7 +17966,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "delete": {
                 "description": "Deletes the Export (and its Provided/Responsibilities entries) for a by-component within a statement.",
@@ -17966,7 +18031,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided": {
@@ -18046,7 +18116,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided/{providedId}": {
@@ -18133,7 +18208,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "delete": {
                 "description": "Deletes an existing ProvidedControlImplementation entry under the Export of a by-component within a statement.",
@@ -18200,7 +18280,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities": {
@@ -18280,7 +18365,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId}": {
@@ -18367,7 +18457,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "delete": {
                 "description": "Deletes an existing ControlImplementationResponsibility entry under the Export of a by-component within a statement.",
@@ -18434,7 +18529,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/suggest-components": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -16498,6 +16498,694 @@ const docTemplate = `{
                 }
             }
         },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export": {
+            "get": {
+                "description": "Retrieves the Export (with nested Provided and Responsibilities) for a by-component within an implemented requirement.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Get the export for a control-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Updates the scalar fields of an existing Export for a by-component within an implemented requirement. Provided and Responsibilities entries are managed via their own routes.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Update the export for a control-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Export data",
+                        "name": "export",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.Export"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates the Export for a by-component within an implemented requirement. A by-component may have at most one Export.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Create the export for a control-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Export data",
+                        "name": "export",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.Export"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the Export (and its Provided/Responsibilities entries) for a by-component within an implemented requirement.",
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Delete the export for a control-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided": {
+            "post": {
+                "description": "Creates a ProvidedControlImplementation entry under the Export of a by-component within an implemented requirement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Create a provided entry on a control-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Provided data",
+                        "name": "provided",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided/{providedId}": {
+            "put": {
+                "description": "Replaces an existing ProvidedControlImplementation entry under the Export of a by-component within an implemented requirement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Update a provided entry on a control-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provided entry ID",
+                        "name": "providedId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Provided data",
+                        "name": "provided",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes an existing ProvidedControlImplementation entry under the Export of a by-component within an implemented requirement.",
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Delete a provided entry on a control-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provided entry ID",
+                        "name": "providedId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities": {
+            "post": {
+                "description": "Creates a ControlImplementationResponsibility entry under the Export of a by-component within an implemented requirement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Create a responsibility entry on a control-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Responsibility data",
+                        "name": "responsibility",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId}": {
+            "put": {
+                "description": "Replaces an existing ControlImplementationResponsibility entry under the Export of a by-component within an implemented requirement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Update a responsibility entry on a control-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Responsibility entry ID",
+                        "name": "responsibilityId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Responsibility data",
+                        "name": "responsibility",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes an existing ControlImplementationResponsibility entry under the Export of a by-component within an implemented requirement.",
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Delete a responsibility entry on a control-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Responsibility entry ID",
+                        "name": "responsibilityId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements": {
             "post": {
                 "description": "Creates a new statement within an implemented requirement for a given SSP.",
@@ -16969,6 +17657,764 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ByComponent"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export": {
+            "get": {
+                "description": "Retrieves the Export (with nested Provided and Responsibilities) for a by-component within a statement.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Get the export for a statement-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Updates the scalar fields of an existing Export for a by-component within a statement. Provided and Responsibilities entries are managed via their own routes.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Update the export for a statement-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Export data",
+                        "name": "export",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.Export"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates the Export for a by-component within a statement. A by-component may have at most one Export.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Create the export for a statement-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Export data",
+                        "name": "export",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.Export"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the Export (and its Provided/Responsibilities entries) for a by-component within a statement.",
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Delete the export for a statement-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided": {
+            "post": {
+                "description": "Creates a ProvidedControlImplementation entry under the Export of a by-component within a statement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Create a provided entry on a statement-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Provided data",
+                        "name": "provided",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided/{providedId}": {
+            "put": {
+                "description": "Replaces an existing ProvidedControlImplementation entry under the Export of a by-component within a statement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Update a provided entry on a statement-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provided entry ID",
+                        "name": "providedId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Provided data",
+                        "name": "provided",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes an existing ProvidedControlImplementation entry under the Export of a by-component within a statement.",
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Delete a provided entry on a statement-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provided entry ID",
+                        "name": "providedId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities": {
+            "post": {
+                "description": "Creates a ControlImplementationResponsibility entry under the Export of a by-component within a statement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Create a responsibility entry on a statement-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Responsibility data",
+                        "name": "responsibility",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId}": {
+            "put": {
+                "description": "Replaces an existing ControlImplementationResponsibility entry under the Export of a by-component within a statement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Update a responsibility entry on a statement-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Responsibility entry ID",
+                        "name": "responsibilityId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Responsibility data",
+                        "name": "responsibility",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes an existing ControlImplementationResponsibility entry under the Export of a by-component within a statement.",
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Delete a responsibility entry on a statement-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Responsibility entry ID",
+                        "name": "responsibilityId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
                     },
                     "400": {
                         "description": "Bad Request",
@@ -31131,6 +32577,19 @@ const docTemplate = `{
                 }
             }
         },
+        "handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Wrapped response data",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility"
+                        }
+                    ]
+                }
+            }
+        },
         "handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationSet": {
             "type": "object",
             "properties": {
@@ -31178,6 +32637,19 @@ const docTemplate = `{
                     "allOf": [
                         {
                             "$ref": "#/definitions/oscalTypes_1_1_3.Diagram"
+                        }
+                    ]
+                }
+            }
+        },
+        "handler.GenericDataResponse-oscalTypes_1_1_3_Export": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Wrapped response data",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.Export"
                         }
                     ]
                 }
@@ -31438,6 +32910,19 @@ const docTemplate = `{
                     "allOf": [
                         {
                             "$ref": "#/definitions/oscalTypes_1_1_3.Profile"
+                        }
+                    ]
+                }
+            }
+        },
+        "handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Wrapped response data",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation"
                         }
                     ]
                 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -16550,7 +16550,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "put": {
                 "description": "Updates the scalar fields of an existing Export for a by-component within an implemented requirement. Provided and Responsibilities entries are managed via their own routes.",
@@ -16621,7 +16626,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "post": {
                 "description": "Creates the Export for a by-component within an implemented requirement. A by-component may have at most one Export.",
@@ -16698,7 +16708,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "delete": {
                 "description": "Deletes the Export (and its Provided/Responsibilities entries) for a by-component within an implemented requirement.",
@@ -16751,7 +16766,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided": {
@@ -16824,7 +16844,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided/{providedId}": {
@@ -16904,7 +16929,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "delete": {
                 "description": "Deletes an existing ProvidedControlImplementation entry under the Export of a by-component within an implemented requirement.",
@@ -16964,7 +16994,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities": {
@@ -17037,7 +17072,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId}": {
@@ -17117,7 +17157,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "delete": {
                 "description": "Deletes an existing ControlImplementationResponsibility entry under the Export of a by-component within an implemented requirement.",
@@ -17177,7 +17222,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements": {
@@ -17497,8 +17547,8 @@
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "201": {
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ByComponent"
                         }
@@ -17738,7 +17788,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "put": {
                 "description": "Updates the scalar fields of an existing Export for a by-component within a statement. Provided and Responsibilities entries are managed via their own routes.",
@@ -17816,7 +17871,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "post": {
                 "description": "Creates the Export for a by-component within a statement. A by-component may have at most one Export.",
@@ -17900,7 +17960,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "delete": {
                 "description": "Deletes the Export (and its Provided/Responsibilities entries) for a by-component within a statement.",
@@ -17960,7 +18025,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided": {
@@ -18040,7 +18110,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided/{providedId}": {
@@ -18127,7 +18202,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "delete": {
                 "description": "Deletes an existing ProvidedControlImplementation entry under the Export of a by-component within a statement.",
@@ -18194,7 +18274,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities": {
@@ -18274,7 +18359,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId}": {
@@ -18361,7 +18451,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             },
             "delete": {
                 "description": "Deletes an existing ControlImplementationResponsibility entry under the Export of a by-component within a statement.",
@@ -18428,7 +18523,12 @@
                             "$ref": "#/definitions/api.Error"
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ]
             }
         },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/suggest-components": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -16492,6 +16492,694 @@
                 }
             }
         },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export": {
+            "get": {
+                "description": "Retrieves the Export (with nested Provided and Responsibilities) for a by-component within an implemented requirement.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Get the export for a control-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Updates the scalar fields of an existing Export for a by-component within an implemented requirement. Provided and Responsibilities entries are managed via their own routes.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Update the export for a control-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Export data",
+                        "name": "export",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.Export"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates the Export for a by-component within an implemented requirement. A by-component may have at most one Export.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Create the export for a control-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Export data",
+                        "name": "export",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.Export"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the Export (and its Provided/Responsibilities entries) for a by-component within an implemented requirement.",
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Delete the export for a control-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided": {
+            "post": {
+                "description": "Creates a ProvidedControlImplementation entry under the Export of a by-component within an implemented requirement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Create a provided entry on a control-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Provided data",
+                        "name": "provided",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided/{providedId}": {
+            "put": {
+                "description": "Replaces an existing ProvidedControlImplementation entry under the Export of a by-component within an implemented requirement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Update a provided entry on a control-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provided entry ID",
+                        "name": "providedId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Provided data",
+                        "name": "provided",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes an existing ProvidedControlImplementation entry under the Export of a by-component within an implemented requirement.",
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Delete a provided entry on a control-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provided entry ID",
+                        "name": "providedId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities": {
+            "post": {
+                "description": "Creates a ControlImplementationResponsibility entry under the Export of a by-component within an implemented requirement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Create a responsibility entry on a control-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Responsibility data",
+                        "name": "responsibility",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId}": {
+            "put": {
+                "description": "Replaces an existing ControlImplementationResponsibility entry under the Export of a by-component within an implemented requirement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Update a responsibility entry on a control-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Responsibility entry ID",
+                        "name": "responsibilityId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Responsibility data",
+                        "name": "responsibility",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes an existing ControlImplementationResponsibility entry under the Export of a by-component within an implemented requirement.",
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Delete a responsibility entry on a control-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Responsibility entry ID",
+                        "name": "responsibilityId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements": {
             "post": {
                 "description": "Creates a new statement within an implemented requirement for a given SSP.",
@@ -16963,6 +17651,764 @@
                         "schema": {
                             "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ByComponent"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export": {
+            "get": {
+                "description": "Retrieves the Export (with nested Provided and Responsibilities) for a by-component within a statement.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Get the export for a statement-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Updates the scalar fields of an existing Export for a by-component within a statement. Provided and Responsibilities entries are managed via their own routes.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Update the export for a statement-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Export data",
+                        "name": "export",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.Export"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates the Export for a by-component within a statement. A by-component may have at most one Export.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Create the export for a statement-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Export data",
+                        "name": "export",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.Export"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes the Export (and its Provided/Responsibilities entries) for a by-component within a statement.",
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Delete the export for a statement-level by-component",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided": {
+            "post": {
+                "description": "Creates a ProvidedControlImplementation entry under the Export of a by-component within a statement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Create a provided entry on a statement-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Provided data",
+                        "name": "provided",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided/{providedId}": {
+            "put": {
+                "description": "Replaces an existing ProvidedControlImplementation entry under the Export of a by-component within a statement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Update a provided entry on a statement-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provided entry ID",
+                        "name": "providedId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Provided data",
+                        "name": "provided",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes an existing ProvidedControlImplementation entry under the Export of a by-component within a statement.",
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Delete a provided entry on a statement-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provided entry ID",
+                        "name": "providedId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities": {
+            "post": {
+                "description": "Creates a ControlImplementationResponsibility entry under the Export of a by-component within a statement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Create a responsibility entry on a statement-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Responsibility data",
+                        "name": "responsibility",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId}": {
+            "put": {
+                "description": "Replaces an existing ControlImplementationResponsibility entry under the Export of a by-component within a statement.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Update a responsibility entry on a statement-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Responsibility entry ID",
+                        "name": "responsibilityId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Responsibility data",
+                        "name": "responsibility",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes an existing ControlImplementationResponsibility entry under the Export of a by-component within a statement.",
+                "tags": [
+                    "System Security Plans"
+                ],
+                "summary": "Delete a responsibility entry on a statement-level by-component's export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SSP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Requirement ID",
+                        "name": "reqId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Statement ID",
+                        "name": "stmtId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "By-Component ID",
+                        "name": "byComponentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Responsibility entry ID",
+                        "name": "responsibilityId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
                     },
                     "400": {
                         "description": "Bad Request",
@@ -31125,6 +32571,19 @@
                 }
             }
         },
+        "handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Wrapped response data",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility"
+                        }
+                    ]
+                }
+            }
+        },
         "handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationSet": {
             "type": "object",
             "properties": {
@@ -31172,6 +32631,19 @@
                     "allOf": [
                         {
                             "$ref": "#/definitions/oscalTypes_1_1_3.Diagram"
+                        }
+                    ]
+                }
+            }
+        },
+        "handler.GenericDataResponse-oscalTypes_1_1_3_Export": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Wrapped response data",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.Export"
                         }
                     ]
                 }
@@ -31432,6 +32904,19 @@
                     "allOf": [
                         {
                             "$ref": "#/definitions/oscalTypes_1_1_3.Profile"
+                        }
+                    ]
+                }
+            }
+        },
+        "handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Wrapped response data",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation"
                         }
                     ]
                 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1457,6 +1457,13 @@ definitions:
         - $ref: '#/definitions/oscalTypes_1_1_3.ControlImplementation'
         description: Wrapped response data
     type: object
+  handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility:
+    properties:
+      data:
+        allOf:
+        - $ref: '#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility'
+        description: Wrapped response data
+    type: object
   handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationSet:
     properties:
       data:
@@ -1483,6 +1490,13 @@ definitions:
       data:
         allOf:
         - $ref: '#/definitions/oscalTypes_1_1_3.Diagram'
+        description: Wrapped response data
+    type: object
+  handler.GenericDataResponse-oscalTypes_1_1_3_Export:
+    properties:
+      data:
+        allOf:
+        - $ref: '#/definitions/oscalTypes_1_1_3.Export'
         description: Wrapped response data
     type: object
   handler.GenericDataResponse-oscalTypes_1_1_3_Finding:
@@ -1623,6 +1637,13 @@ definitions:
       data:
         allOf:
         - $ref: '#/definitions/oscalTypes_1_1_3.Profile'
+        description: Wrapped response data
+    type: object
+  handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation:
+    properties:
+      data:
+        allOf:
+        - $ref: '#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation'
         description: Wrapped response data
     type: object
   handler.GenericDataResponse-oscalTypes_1_1_3_Resource:
@@ -21470,6 +21491,482 @@ paths:
       summary: Update a by-component within an implemented requirement
       tags:
       - System Security Plans
+  /oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export:
+    delete:
+      description: Deletes the Export (and its Provided/Responsibilities entries)
+        for a by-component within an implemented requirement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Delete the export for a control-level by-component
+      tags:
+      - System Security Plans
+    get:
+      description: Retrieves the Export (with nested Provided and Responsibilities)
+        for a by-component within an implemented requirement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Get the export for a control-level by-component
+      tags:
+      - System Security Plans
+    post:
+      consumes:
+      - application/json
+      description: Creates the Export for a by-component within an implemented requirement.
+        A by-component may have at most one Export.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Export data
+        in: body
+        name: export
+        required: true
+        schema:
+          $ref: '#/definitions/oscalTypes_1_1_3.Export'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Create the export for a control-level by-component
+      tags:
+      - System Security Plans
+    put:
+      consumes:
+      - application/json
+      description: Updates the scalar fields of an existing Export for a by-component
+        within an implemented requirement. Provided and Responsibilities entries are
+        managed via their own routes.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Export data
+        in: body
+        name: export
+        required: true
+        schema:
+          $ref: '#/definitions/oscalTypes_1_1_3.Export'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Update the export for a control-level by-component
+      tags:
+      - System Security Plans
+  ? /oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided
+  : post:
+      consumes:
+      - application/json
+      description: Creates a ProvidedControlImplementation entry under the Export
+        of a by-component within an implemented requirement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Provided data
+        in: body
+        name: provided
+        required: true
+        schema:
+          $ref: '#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Create a provided entry on a control-level by-component's export
+      tags:
+      - System Security Plans
+  ? /oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided/{providedId}
+  : delete:
+      description: Deletes an existing ProvidedControlImplementation entry under the
+        Export of a by-component within an implemented requirement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Provided entry ID
+        in: path
+        name: providedId
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Delete a provided entry on a control-level by-component's export
+      tags:
+      - System Security Plans
+    put:
+      consumes:
+      - application/json
+      description: Replaces an existing ProvidedControlImplementation entry under
+        the Export of a by-component within an implemented requirement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Provided entry ID
+        in: path
+        name: providedId
+        required: true
+        type: string
+      - description: Provided data
+        in: body
+        name: provided
+        required: true
+        schema:
+          $ref: '#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Update a provided entry on a control-level by-component's export
+      tags:
+      - System Security Plans
+  ? /oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities
+  : post:
+      consumes:
+      - application/json
+      description: Creates a ControlImplementationResponsibility entry under the Export
+        of a by-component within an implemented requirement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Responsibility data
+        in: body
+        name: responsibility
+        required: true
+        schema:
+          $ref: '#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Create a responsibility entry on a control-level by-component's export
+      tags:
+      - System Security Plans
+  ? /oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId}
+  : delete:
+      description: Deletes an existing ControlImplementationResponsibility entry under
+        the Export of a by-component within an implemented requirement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Responsibility entry ID
+        in: path
+        name: responsibilityId
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Delete a responsibility entry on a control-level by-component's export
+      tags:
+      - System Security Plans
+    put:
+      consumes:
+      - application/json
+      description: Replaces an existing ControlImplementationResponsibility entry
+        under the Export of a by-component within an implemented requirement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Responsibility entry ID
+        in: path
+        name: responsibilityId
+        required: true
+        type: string
+      - description: Responsibility data
+        in: body
+        name: responsibility
+        required: true
+        schema:
+          $ref: '#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Update a responsibility entry on a control-level by-component's export
+      tags:
+      - System Security Plans
   /oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements:
     post:
       consumes:
@@ -21804,6 +22301,532 @@ paths:
           schema:
             $ref: '#/definitions/api.Error'
       summary: Update a by-component within a statement (within an implemented requirement)
+      tags:
+      - System Security Plans
+  ? /oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export
+  : delete:
+      description: Deletes the Export (and its Provided/Responsibilities entries)
+        for a by-component within a statement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: Statement ID
+        in: path
+        name: stmtId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Delete the export for a statement-level by-component
+      tags:
+      - System Security Plans
+    get:
+      description: Retrieves the Export (with nested Provided and Responsibilities)
+        for a by-component within a statement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: Statement ID
+        in: path
+        name: stmtId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Get the export for a statement-level by-component
+      tags:
+      - System Security Plans
+    post:
+      consumes:
+      - application/json
+      description: Creates the Export for a by-component within a statement. A by-component
+        may have at most one Export.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: Statement ID
+        in: path
+        name: stmtId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Export data
+        in: body
+        name: export
+        required: true
+        schema:
+          $ref: '#/definitions/oscalTypes_1_1_3.Export'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Create the export for a statement-level by-component
+      tags:
+      - System Security Plans
+    put:
+      consumes:
+      - application/json
+      description: Updates the scalar fields of an existing Export for a by-component
+        within a statement. Provided and Responsibilities entries are managed via
+        their own routes.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: Statement ID
+        in: path
+        name: stmtId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Export data
+        in: body
+        name: export
+        required: true
+        schema:
+          $ref: '#/definitions/oscalTypes_1_1_3.Export'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_Export'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Update the export for a statement-level by-component
+      tags:
+      - System Security Plans
+  ? /oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided
+  : post:
+      consumes:
+      - application/json
+      description: Creates a ProvidedControlImplementation entry under the Export
+        of a by-component within a statement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: Statement ID
+        in: path
+        name: stmtId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Provided data
+        in: body
+        name: provided
+        required: true
+        schema:
+          $ref: '#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Create a provided entry on a statement-level by-component's export
+      tags:
+      - System Security Plans
+  ? /oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided/{providedId}
+  : delete:
+      description: Deletes an existing ProvidedControlImplementation entry under the
+        Export of a by-component within a statement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: Statement ID
+        in: path
+        name: stmtId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Provided entry ID
+        in: path
+        name: providedId
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Delete a provided entry on a statement-level by-component's export
+      tags:
+      - System Security Plans
+    put:
+      consumes:
+      - application/json
+      description: Replaces an existing ProvidedControlImplementation entry under
+        the Export of a by-component within a statement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: Statement ID
+        in: path
+        name: stmtId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Provided entry ID
+        in: path
+        name: providedId
+        required: true
+        type: string
+      - description: Provided data
+        in: body
+        name: provided
+        required: true
+        schema:
+          $ref: '#/definitions/oscalTypes_1_1_3.ProvidedControlImplementation'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ProvidedControlImplementation'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Update a provided entry on a statement-level by-component's export
+      tags:
+      - System Security Plans
+  ? /oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities
+  : post:
+      consumes:
+      - application/json
+      description: Creates a ControlImplementationResponsibility entry under the Export
+        of a by-component within a statement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: Statement ID
+        in: path
+        name: stmtId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Responsibility data
+        in: body
+        name: responsibility
+        required: true
+        schema:
+          $ref: '#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Create a responsibility entry on a statement-level by-component's export
+      tags:
+      - System Security Plans
+  ? /oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId}
+  : delete:
+      description: Deletes an existing ControlImplementationResponsibility entry under
+        the Export of a by-component within a statement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: Statement ID
+        in: path
+        name: stmtId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Responsibility entry ID
+        in: path
+        name: responsibilityId
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Delete a responsibility entry on a statement-level by-component's export
+      tags:
+      - System Security Plans
+    put:
+      consumes:
+      - application/json
+      description: Replaces an existing ControlImplementationResponsibility entry
+        under the Export of a by-component within a statement.
+      parameters:
+      - description: SSP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requirement ID
+        in: path
+        name: reqId
+        required: true
+        type: string
+      - description: Statement ID
+        in: path
+        name: stmtId
+        required: true
+        type: string
+      - description: By-Component ID
+        in: path
+        name: byComponentId
+        required: true
+        type: string
+      - description: Responsibility entry ID
+        in: path
+        name: responsibilityId
+        required: true
+        type: string
+      - description: Responsibility data
+        in: body
+        name: responsibility
+        required: true
+        schema:
+          $ref: '#/definitions/oscalTypes_1_1_3.ControlImplementationResponsibility'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ControlImplementationResponsibility'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Update a responsibility entry on a statement-level by-component's export
       tags:
       - System Security Plans
   /oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/suggest-components:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -21526,6 +21526,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Delete the export for a control-level by-component
       tags:
       - System Security Plans
@@ -21567,6 +21569,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Get the export for a control-level by-component
       tags:
       - System Security Plans
@@ -21620,6 +21624,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Create the export for a control-level by-component
       tags:
       - System Security Plans
@@ -21670,6 +21676,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Update the export for a control-level by-component
       tags:
       - System Security Plans
@@ -21720,6 +21728,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Create a provided entry on a control-level by-component's export
       tags:
       - System Security Plans
@@ -21763,6 +21773,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Delete a provided entry on a control-level by-component's export
       tags:
       - System Security Plans
@@ -21817,6 +21829,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Update a provided entry on a control-level by-component's export
       tags:
       - System Security Plans
@@ -21867,6 +21881,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Create a responsibility entry on a control-level by-component's export
       tags:
       - System Security Plans
@@ -21910,6 +21926,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Delete a responsibility entry on a control-level by-component's export
       tags:
       - System Security Plans
@@ -21964,6 +21982,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Update a responsibility entry on a control-level by-component's export
       tags:
       - System Security Plans
@@ -22181,8 +22201,8 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
+        "201":
+          description: Created
           schema:
             $ref: '#/definitions/handler.GenericDataResponse-oscalTypes_1_1_3_ByComponent'
         "400":
@@ -22343,6 +22363,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Delete the export for a statement-level by-component
       tags:
       - System Security Plans
@@ -22389,6 +22411,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Get the export for a statement-level by-component
       tags:
       - System Security Plans
@@ -22447,6 +22471,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Create the export for a statement-level by-component
       tags:
       - System Security Plans
@@ -22502,6 +22528,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Update the export for a statement-level by-component
       tags:
       - System Security Plans
@@ -22557,6 +22585,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Create a provided entry on a statement-level by-component's export
       tags:
       - System Security Plans
@@ -22605,6 +22635,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Delete a provided entry on a statement-level by-component's export
       tags:
       - System Security Plans
@@ -22664,6 +22696,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Update a provided entry on a statement-level by-component's export
       tags:
       - System Security Plans
@@ -22719,6 +22753,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Create a responsibility entry on a statement-level by-component's export
       tags:
       - System Security Plans
@@ -22767,6 +22803,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Delete a responsibility entry on a statement-level by-component's export
       tags:
       - System Security Plans
@@ -22826,6 +22864,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.Error'
+      security:
+      - OAuth2Password: []
       summary: Update a responsibility entry on a statement-level by-component's export
       tags:
       - System Security Plans

--- a/internal/api/handler/oscal/system_security_plans.go
+++ b/internal/api/handler/oscal/system_security_plans.go
@@ -2,6 +2,8 @@ package oscal
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net/http"
@@ -4539,7 +4541,7 @@ func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementStatementByCompo
 //	@Param			reqId			path		string							true	"Requirement ID"
 //	@Param			stmtId			path		string							true	"Statement ID"
 //	@Param			by-component	body		oscalTypes_1_1_3.ByComponent	true	"By-Component data"
-//	@Success		200				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.ByComponent]
+//	@Success		201				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.ByComponent]
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
@@ -4776,15 +4778,6 @@ func (h *SystemSecurityPlanHandler) getByComponentExport(ctx echo.Context, bc *r
 // createByComponentExport creates the (singleton) Export sub-resource for an
 // already-resolved by-component. A by-component may have at most one Export.
 func (h *SystemSecurityPlanHandler) createByComponentExport(ctx echo.Context, bc *relational.ByComponent) error {
-	var existing relational.Export
-	err := h.db.Where("by_component_id = ?", bc.ID).First(&existing).Error
-	if err == nil {
-		return ctx.JSON(http.StatusConflict, api.NewError(fmt.Errorf("export already exists for this by-component")))
-	}
-	if !errors.Is(err, gorm.ErrRecordNotFound) {
-		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
-	}
-
 	var oscalExport oscalTypes_1_1_3.Export
 	if err := ctx.Bind(&oscalExport); err != nil {
 		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
@@ -4794,8 +4787,31 @@ func (h *SystemSecurityPlanHandler) createByComponentExport(ctx echo.Context, bc
 	relExport.UnmarshalOscal(oscalExport)
 	relExport.ByComponentId = *bc.ID
 
-	if err := h.db.Create(relExport).Error; err != nil {
+	conflict := false
+	if err := h.db.Transaction(func(tx *gorm.DB) error {
+		// Export.ByComponentId has no unique DB constraint (this ticket makes no
+		// schema change), so an advisory lock keyed on the by-component closes the
+		// race between the existence check and the insert for concurrent creates.
+		if err := lockByComponentExportCreate(tx, *bc.ID); err != nil {
+			return err
+		}
+
+		var existing relational.Export
+		err := tx.Where("by_component_id = ?", bc.ID).First(&existing).Error
+		if err == nil {
+			conflict = true
+			return nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
+		return tx.Create(relExport).Error
+	}); err != nil {
 		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+	if conflict {
+		return ctx.JSON(http.StatusConflict, api.NewError(fmt.Errorf("export already exists for this by-component")))
 	}
 
 	created, err := h.reloadByComponentExport(*bc.ID)
@@ -4803,6 +4819,19 @@ func (h *SystemSecurityPlanHandler) createByComponentExport(ctx echo.Context, bc
 		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
 	}
 	return ctx.JSON(http.StatusCreated, handler.GenericDataResponse[oscalTypes_1_1_3.Export]{Data: *created.MarshalOscal()})
+}
+
+// lockByComponentExportCreate serializes concurrent Export creation for the same
+// by-component using a transaction-scoped Postgres advisory lock keyed on the
+// by-component's UUID. It is a no-op against non-Postgres test drivers.
+func lockByComponentExportCreate(tx *gorm.DB, byComponentID uuid.UUID) error {
+	if tx.Name() != "postgres" {
+		return nil
+	}
+	sum := sha256.Sum256([]byte("export-create:" + byComponentID.String()))
+	key1 := int32(binary.BigEndian.Uint32(sum[0:4]))
+	key2 := int32(binary.BigEndian.Uint32(sum[4:8]))
+	return tx.Exec("SELECT pg_advisory_xact_lock(?, ?)", key1, key2).Error
 }
 
 // updateByComponentExport updates the scalar fields (description, remarks, props,
@@ -4888,6 +4917,7 @@ func (h *SystemSecurityPlanHandler) deleteByComponentExport(ctx echo.Context, bc
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export [get]
 func (h *SystemSecurityPlanHandler) GetImplementedRequirementByComponentExport(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForRequirement(ctx)
@@ -4913,6 +4943,7 @@ func (h *SystemSecurityPlanHandler) GetImplementedRequirementByComponentExport(c
 //	@Failure		404				{object}	api.Error
 //	@Failure		409				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export [post]
 func (h *SystemSecurityPlanHandler) CreateImplementedRequirementByComponentExport(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForRequirement(ctx)
@@ -4937,6 +4968,7 @@ func (h *SystemSecurityPlanHandler) CreateImplementedRequirementByComponentExpor
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export [put]
 func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementByComponentExport(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForRequirement(ctx)
@@ -4958,6 +4990,7 @@ func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementByComponentExpor
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export [delete]
 func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementByComponentExport(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForRequirement(ctx)
@@ -4981,6 +5014,7 @@ func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementByComponentExpor
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export [get]
 func (h *SystemSecurityPlanHandler) GetImplementedRequirementStatementByComponentExport(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForStatement(ctx)
@@ -5007,6 +5041,7 @@ func (h *SystemSecurityPlanHandler) GetImplementedRequirementStatementByComponen
 //	@Failure		404				{object}	api.Error
 //	@Failure		409				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export [post]
 func (h *SystemSecurityPlanHandler) CreateImplementedRequirementStatementByComponentExport(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForStatement(ctx)
@@ -5032,6 +5067,7 @@ func (h *SystemSecurityPlanHandler) CreateImplementedRequirementStatementByCompo
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export [put]
 func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementStatementByComponentExport(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForStatement(ctx)
@@ -5054,6 +5090,7 @@ func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementStatementByCompo
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export [delete]
 func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementStatementByComponentExport(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForStatement(ctx)
@@ -5183,6 +5220,7 @@ func (h *SystemSecurityPlanHandler) deleteByComponentExportProvided(ctx echo.Con
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided [post]
 func (h *SystemSecurityPlanHandler) CreateImplementedRequirementByComponentExportProvided(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForRequirement(ctx)
@@ -5208,6 +5246,7 @@ func (h *SystemSecurityPlanHandler) CreateImplementedRequirementByComponentExpor
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided/{providedId} [put]
 func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementByComponentExportProvided(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForRequirement(ctx)
@@ -5230,6 +5269,7 @@ func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementByComponentExpor
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided/{providedId} [delete]
 func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementByComponentExportProvided(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForRequirement(ctx)
@@ -5255,6 +5295,7 @@ func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementByComponentExpor
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided [post]
 func (h *SystemSecurityPlanHandler) CreateImplementedRequirementStatementByComponentExportProvided(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForStatement(ctx)
@@ -5281,6 +5322,7 @@ func (h *SystemSecurityPlanHandler) CreateImplementedRequirementStatementByCompo
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided/{providedId} [put]
 func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementStatementByComponentExportProvided(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForStatement(ctx)
@@ -5304,6 +5346,7 @@ func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementStatementByCompo
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided/{providedId} [delete]
 func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementStatementByComponentExportProvided(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForStatement(ctx)
@@ -5418,6 +5461,7 @@ func (h *SystemSecurityPlanHandler) deleteByComponentExportResponsibility(ctx ec
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities [post]
 func (h *SystemSecurityPlanHandler) CreateImplementedRequirementByComponentExportResponsibility(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForRequirement(ctx)
@@ -5443,6 +5487,7 @@ func (h *SystemSecurityPlanHandler) CreateImplementedRequirementByComponentExpor
 //	@Failure		400					{object}	api.Error
 //	@Failure		404					{object}	api.Error
 //	@Failure		500					{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId} [put]
 func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementByComponentExportResponsibility(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForRequirement(ctx)
@@ -5465,6 +5510,7 @@ func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementByComponentExpor
 //	@Failure		400					{object}	api.Error
 //	@Failure		404					{object}	api.Error
 //	@Failure		500					{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId} [delete]
 func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementByComponentExportResponsibility(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForRequirement(ctx)
@@ -5490,6 +5536,7 @@ func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementByComponentExpor
 //	@Failure		400				{object}	api.Error
 //	@Failure		404				{object}	api.Error
 //	@Failure		500				{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities [post]
 func (h *SystemSecurityPlanHandler) CreateImplementedRequirementStatementByComponentExportResponsibility(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForStatement(ctx)
@@ -5516,6 +5563,7 @@ func (h *SystemSecurityPlanHandler) CreateImplementedRequirementStatementByCompo
 //	@Failure		400					{object}	api.Error
 //	@Failure		404					{object}	api.Error
 //	@Failure		500					{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId} [put]
 func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementStatementByComponentExportResponsibility(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForStatement(ctx)
@@ -5539,6 +5587,7 @@ func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementStatementByCompo
 //	@Failure		400					{object}	api.Error
 //	@Failure		404					{object}	api.Error
 //	@Failure		500					{object}	api.Error
+//	@Security		OAuth2Password
 //	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId} [delete]
 func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementStatementByComponentExportResponsibility(ctx echo.Context) error {
 	bc, ok := h.resolveByComponentForStatement(ctx)

--- a/internal/api/handler/oscal/system_security_plans.go
+++ b/internal/api/handler/oscal/system_security_plans.go
@@ -468,6 +468,26 @@ func (h *SystemSecurityPlanHandler) Register(api *echo.Group, guard middleware.R
 	api.PUT("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components/:byComponentId", h.UpdateImplementedRequirementStatementByComponent, guard.Update())
 	api.DELETE("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components/:byComponentId", h.DeleteImplementedRequirementStatementByComponent, guard.Delete())
 	api.POST("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components", h.CreateImplementedRequirementStatementByComponent, guard.Create())
+	api.GET("/:id/control-implementation/implemented-requirements/:reqId/by-components/:byComponentId/export", h.GetImplementedRequirementByComponentExport, guard.Read())
+	api.POST("/:id/control-implementation/implemented-requirements/:reqId/by-components/:byComponentId/export", h.CreateImplementedRequirementByComponentExport, guard.Create())
+	api.PUT("/:id/control-implementation/implemented-requirements/:reqId/by-components/:byComponentId/export", h.UpdateImplementedRequirementByComponentExport, guard.Update())
+	api.DELETE("/:id/control-implementation/implemented-requirements/:reqId/by-components/:byComponentId/export", h.DeleteImplementedRequirementByComponentExport, guard.Delete())
+	api.POST("/:id/control-implementation/implemented-requirements/:reqId/by-components/:byComponentId/export/provided", h.CreateImplementedRequirementByComponentExportProvided, guard.Create())
+	api.PUT("/:id/control-implementation/implemented-requirements/:reqId/by-components/:byComponentId/export/provided/:providedId", h.UpdateImplementedRequirementByComponentExportProvided, guard.Update())
+	api.DELETE("/:id/control-implementation/implemented-requirements/:reqId/by-components/:byComponentId/export/provided/:providedId", h.DeleteImplementedRequirementByComponentExportProvided, guard.Delete())
+	api.POST("/:id/control-implementation/implemented-requirements/:reqId/by-components/:byComponentId/export/responsibilities", h.CreateImplementedRequirementByComponentExportResponsibility, guard.Create())
+	api.PUT("/:id/control-implementation/implemented-requirements/:reqId/by-components/:byComponentId/export/responsibilities/:responsibilityId", h.UpdateImplementedRequirementByComponentExportResponsibility, guard.Update())
+	api.DELETE("/:id/control-implementation/implemented-requirements/:reqId/by-components/:byComponentId/export/responsibilities/:responsibilityId", h.DeleteImplementedRequirementByComponentExportResponsibility, guard.Delete())
+	api.GET("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components/:byComponentId/export", h.GetImplementedRequirementStatementByComponentExport, guard.Read())
+	api.POST("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components/:byComponentId/export", h.CreateImplementedRequirementStatementByComponentExport, guard.Create())
+	api.PUT("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components/:byComponentId/export", h.UpdateImplementedRequirementStatementByComponentExport, guard.Update())
+	api.DELETE("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components/:byComponentId/export", h.DeleteImplementedRequirementStatementByComponentExport, guard.Delete())
+	api.POST("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components/:byComponentId/export/provided", h.CreateImplementedRequirementStatementByComponentExportProvided, guard.Create())
+	api.PUT("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components/:byComponentId/export/provided/:providedId", h.UpdateImplementedRequirementStatementByComponentExportProvided, guard.Update())
+	api.DELETE("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components/:byComponentId/export/provided/:providedId", h.DeleteImplementedRequirementStatementByComponentExportProvided, guard.Delete())
+	api.POST("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components/:byComponentId/export/responsibilities", h.CreateImplementedRequirementStatementByComponentExportResponsibility, guard.Create())
+	api.PUT("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components/:byComponentId/export/responsibilities/:responsibilityId", h.UpdateImplementedRequirementStatementByComponentExportResponsibility, guard.Update())
+	api.DELETE("/:id/control-implementation/implemented-requirements/:reqId/statements/:stmtId/by-components/:byComponentId/export/responsibilities/:responsibilityId", h.DeleteImplementedRequirementStatementByComponentExportResponsibility, guard.Delete())
 	api.DELETE("/:id/control-implementation/implemented-requirements/:reqId", h.DeleteImplementedRequirement, guard.Delete())
 	api.POST("/:id/control-implementation/implemented-requirements/:reqId/suggest-components", h.SuggestComponents, guard.Read())
 	api.POST("/:id/control-implementation/implemented-requirements/:reqId/apply-suggestion", h.ApplySuggestion, guard.Update())
@@ -4600,6 +4620,932 @@ func (h *SystemSecurityPlanHandler) CreateImplementedRequirementStatementByCompo
 
 	// Step 7: Return created
 	return ctx.JSON(http.StatusCreated, handler.GenericDataResponse[oscalTypes_1_1_3.ByComponent]{Data: *relBC.MarshalOscal()})
+}
+
+// resolveByComponentForRequirement parses and verifies a by-component that belongs
+// directly to an implemented requirement (control-level). On any failure it writes
+// the appropriate JSON error response to ctx and returns ok=false; callers should
+// return nil immediately when ok is false.
+func (h *SystemSecurityPlanHandler) resolveByComponentForRequirement(ctx echo.Context) (bc *relational.ByComponent, ok bool) {
+	sspID, reqID, err := parseSSPReqIDs(ctx)
+	if err != nil {
+		h.sugar.Warnw("Invalid by-component path params", "error", err)
+		_ = ctx.JSON(http.StatusBadRequest, api.NewError(err))
+		return nil, false
+	}
+
+	byComponentIdParam := ctx.Param("byComponentId")
+	byComponentID, err := uuid.Parse(byComponentIdParam)
+	if err != nil {
+		h.sugar.Warnw("Invalid component id", "byComponentId", byComponentIdParam, "error", err)
+		_ = ctx.JSON(http.StatusBadRequest, api.NewError(err))
+		return nil, false
+	}
+
+	var ssp relational.SystemSecurityPlan
+	if err := h.db.Preload("ControlImplementation").First(&ssp, "id = ?", sspID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			_ = ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("SSP not found")))
+			return nil, false
+		}
+		_ = ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+		return nil, false
+	}
+
+	var req relational.ImplementedRequirement
+	if err := h.db.Where("id = ? AND control_implementation_id = ?", reqID, ssp.ControlImplementation.ID).
+		First(&req).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			_ = ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("requirement not found")))
+			return nil, false
+		}
+		_ = ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+		return nil, false
+	}
+
+	var found relational.ByComponent
+	if err := h.db.Where("id = ? AND parent_id = ? AND parent_type = ?",
+		byComponentID, req.ID, "implemented_requirements").
+		First(&found).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			_ = ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("by-component not found")))
+			return nil, false
+		}
+		_ = ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+		return nil, false
+	}
+
+	return &found, true
+}
+
+// resolveByComponentForStatement parses and verifies a by-component that belongs to
+// a statement within an implemented requirement (statement-level). Same contract as
+// resolveByComponentForRequirement.
+func (h *SystemSecurityPlanHandler) resolveByComponentForStatement(ctx echo.Context) (bc *relational.ByComponent, ok bool) {
+	sspID, reqID, stmtID, err := parseSSPReqStmtIDs(ctx)
+	if err != nil {
+		h.sugar.Warnw("Invalid by-component path params", "error", err)
+		_ = ctx.JSON(http.StatusBadRequest, api.NewError(err))
+		return nil, false
+	}
+
+	byComponentIdParam := ctx.Param("byComponentId")
+	byComponentID, err := uuid.Parse(byComponentIdParam)
+	if err != nil {
+		h.sugar.Warnw("Invalid component id", "byComponentId", byComponentIdParam, "error", err)
+		_ = ctx.JSON(http.StatusBadRequest, api.NewError(err))
+		return nil, false
+	}
+
+	var ssp relational.SystemSecurityPlan
+	if err := h.db.Preload("ControlImplementation").First(&ssp, "id = ?", sspID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			_ = ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("SSP not found")))
+			return nil, false
+		}
+		_ = ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+		return nil, false
+	}
+
+	var req relational.ImplementedRequirement
+	if err := h.db.Where("id = ? AND control_implementation_id = ?", reqID, ssp.ControlImplementation.ID).
+		First(&req).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			_ = ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("requirement not found")))
+			return nil, false
+		}
+		_ = ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+		return nil, false
+	}
+
+	var stmt relational.Statement
+	if err := h.db.Where("id = ? AND implemented_requirement_id = ?", stmtID, req.ID).
+		First(&stmt).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			_ = ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("statement not found")))
+			return nil, false
+		}
+		_ = ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+		return nil, false
+	}
+
+	var found relational.ByComponent
+	if err := h.db.Where("id = ? AND parent_id = ? AND parent_type = ?",
+		byComponentID, stmt.ID, "statements").
+		First(&found).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			_ = ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("by-component not found")))
+			return nil, false
+		}
+		_ = ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+		return nil, false
+	}
+
+	return &found, true
+}
+
+// reloadByComponentExport re-fetches a by-component's Export with its nested Provided
+// and Responsibilities (and their responsible roles) fully preloaded, for use in
+// responses after a create/update.
+func (h *SystemSecurityPlanHandler) reloadByComponentExport(byComponentID uuid.UUID) (*relational.Export, error) {
+	var export relational.Export
+	err := h.db.
+		Preload("Provided").
+		Preload("Provided.ResponsibleRoles").
+		Preload("Provided.ResponsibleRoles.Parties").
+		Preload("Responsibilities").
+		Preload("Responsibilities.ResponsibleRoles").
+		Preload("Responsibilities.ResponsibleRoles.Parties").
+		Where("by_component_id = ?", byComponentID).
+		First(&export).Error
+	return &export, err
+}
+
+// getByComponentExport reads the Export sub-resource for an already-resolved by-component.
+func (h *SystemSecurityPlanHandler) getByComponentExport(ctx echo.Context, bc *relational.ByComponent) error {
+	export, err := h.reloadByComponentExport(*bc.ID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("export not found")))
+		}
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+	return ctx.JSON(http.StatusOK, handler.GenericDataResponse[oscalTypes_1_1_3.Export]{Data: *export.MarshalOscal()})
+}
+
+// createByComponentExport creates the (singleton) Export sub-resource for an
+// already-resolved by-component. A by-component may have at most one Export.
+func (h *SystemSecurityPlanHandler) createByComponentExport(ctx echo.Context, bc *relational.ByComponent) error {
+	var existing relational.Export
+	err := h.db.Where("by_component_id = ?", bc.ID).First(&existing).Error
+	if err == nil {
+		return ctx.JSON(http.StatusConflict, api.NewError(fmt.Errorf("export already exists for this by-component")))
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	var oscalExport oscalTypes_1_1_3.Export
+	if err := ctx.Bind(&oscalExport); err != nil {
+		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
+	}
+
+	relExport := &relational.Export{}
+	relExport.UnmarshalOscal(oscalExport)
+	relExport.ByComponentId = *bc.ID
+
+	if err := h.db.Create(relExport).Error; err != nil {
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	created, err := h.reloadByComponentExport(*bc.ID)
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+	return ctx.JSON(http.StatusCreated, handler.GenericDataResponse[oscalTypes_1_1_3.Export]{Data: *created.MarshalOscal()})
+}
+
+// updateByComponentExport updates the scalar fields (description, remarks, props,
+// links) of an existing Export. The Provided and Responsibilities entries are managed
+// individually via their own routes and are left untouched here.
+func (h *SystemSecurityPlanHandler) updateByComponentExport(ctx echo.Context, bc *relational.ByComponent) error {
+	var existing relational.Export
+	if err := h.db.Where("by_component_id = ?", bc.ID).First(&existing).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("export not found")))
+		}
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	var oscalExport oscalTypes_1_1_3.Export
+	if err := ctx.Bind(&oscalExport); err != nil {
+		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
+	}
+
+	if oscalExport.Provided != nil && len(*oscalExport.Provided) > 0 {
+		return ctx.JSON(http.StatusBadRequest, api.NewError(fmt.Errorf("provided entries must be managed via the export/provided routes, not by updating the export directly")))
+	}
+	if oscalExport.Responsibilities != nil && len(*oscalExport.Responsibilities) > 0 {
+		return ctx.JSON(http.StatusBadRequest, api.NewError(fmt.Errorf("responsibility entries must be managed via the export/responsibilities routes, not by updating the export directly")))
+	}
+
+	parsed := &relational.Export{}
+	parsed.UnmarshalOscal(oscalExport)
+
+	existing.Description = parsed.Description
+	existing.Remarks = parsed.Remarks
+	existing.Props = parsed.Props
+	existing.Links = parsed.Links
+
+	if err := h.db.Save(&existing).Error; err != nil {
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	updated, err := h.reloadByComponentExport(*bc.ID)
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+	return ctx.JSON(http.StatusOK, handler.GenericDataResponse[oscalTypes_1_1_3.Export]{Data: *updated.MarshalOscal()})
+}
+
+// deleteByComponentExport deletes an existing Export and its nested Provided and
+// Responsibilities entries. Children are deleted explicitly rather than relying on a
+// DB-level cascade, since this ticket makes no schema change.
+func (h *SystemSecurityPlanHandler) deleteByComponentExport(ctx echo.Context, bc *relational.ByComponent) error {
+	var existing relational.Export
+	if err := h.db.Where("by_component_id = ?", bc.ID).First(&existing).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("export not found")))
+		}
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	if err := h.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("export_id = ?", existing.ID).Delete(&relational.ProvidedControlImplementation{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("export_id = ?", existing.ID).Delete(&relational.ControlImplementationResponsibility{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&existing).Error
+	}); err != nil {
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	return ctx.NoContent(http.StatusNoContent)
+}
+
+// GetImplementedRequirementByComponentExport godoc
+//
+//	@Summary		Get the export for a control-level by-component
+//	@Description	Retrieves the Export (with nested Provided and Responsibilities) for a by-component within an implemented requirement.
+//	@Tags			System Security Plans
+//	@Produce		json
+//	@Param			id				path		string	true	"SSP ID"
+//	@Param			reqId			path		string	true	"Requirement ID"
+//	@Param			byComponentId	path		string	true	"By-Component ID"
+//	@Success		200				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export [get]
+func (h *SystemSecurityPlanHandler) GetImplementedRequirementByComponentExport(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForRequirement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.getByComponentExport(ctx, bc)
+}
+
+// CreateImplementedRequirementByComponentExport godoc
+//
+//	@Summary		Create the export for a control-level by-component
+//	@Description	Creates the Export for a by-component within an implemented requirement. A by-component may have at most one Export.
+//	@Tags			System Security Plans
+//	@Accept			json
+//	@Produce		json
+//	@Param			id				path		string					true	"SSP ID"
+//	@Param			reqId			path		string					true	"Requirement ID"
+//	@Param			byComponentId	path		string					true	"By-Component ID"
+//	@Param			export			body		oscalTypes_1_1_3.Export	true	"Export data"
+//	@Success		201				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		409				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export [post]
+func (h *SystemSecurityPlanHandler) CreateImplementedRequirementByComponentExport(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForRequirement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.createByComponentExport(ctx, bc)
+}
+
+// UpdateImplementedRequirementByComponentExport godoc
+//
+//	@Summary		Update the export for a control-level by-component
+//	@Description	Updates the scalar fields of an existing Export for a by-component within an implemented requirement. Provided and Responsibilities entries are managed via their own routes.
+//	@Tags			System Security Plans
+//	@Accept			json
+//	@Produce		json
+//	@Param			id				path		string					true	"SSP ID"
+//	@Param			reqId			path		string					true	"Requirement ID"
+//	@Param			byComponentId	path		string					true	"By-Component ID"
+//	@Param			export			body		oscalTypes_1_1_3.Export	true	"Export data"
+//	@Success		200				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export [put]
+func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementByComponentExport(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForRequirement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.updateByComponentExport(ctx, bc)
+}
+
+// DeleteImplementedRequirementByComponentExport godoc
+//
+//	@Summary		Delete the export for a control-level by-component
+//	@Description	Deletes the Export (and its Provided/Responsibilities entries) for a by-component within an implemented requirement.
+//	@Tags			System Security Plans
+//	@Param			id				path	string	true	"SSP ID"
+//	@Param			reqId			path	string	true	"Requirement ID"
+//	@Param			byComponentId	path	string	true	"By-Component ID"
+//	@Success		204				"No Content"
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export [delete]
+func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementByComponentExport(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForRequirement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.deleteByComponentExport(ctx, bc)
+}
+
+// GetImplementedRequirementStatementByComponentExport godoc
+//
+//	@Summary		Get the export for a statement-level by-component
+//	@Description	Retrieves the Export (with nested Provided and Responsibilities) for a by-component within a statement.
+//	@Tags			System Security Plans
+//	@Produce		json
+//	@Param			id				path		string	true	"SSP ID"
+//	@Param			reqId			path		string	true	"Requirement ID"
+//	@Param			stmtId			path		string	true	"Statement ID"
+//	@Param			byComponentId	path		string	true	"By-Component ID"
+//	@Success		200				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export [get]
+func (h *SystemSecurityPlanHandler) GetImplementedRequirementStatementByComponentExport(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForStatement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.getByComponentExport(ctx, bc)
+}
+
+// CreateImplementedRequirementStatementByComponentExport godoc
+//
+//	@Summary		Create the export for a statement-level by-component
+//	@Description	Creates the Export for a by-component within a statement. A by-component may have at most one Export.
+//	@Tags			System Security Plans
+//	@Accept			json
+//	@Produce		json
+//	@Param			id				path		string					true	"SSP ID"
+//	@Param			reqId			path		string					true	"Requirement ID"
+//	@Param			stmtId			path		string					true	"Statement ID"
+//	@Param			byComponentId	path		string					true	"By-Component ID"
+//	@Param			export			body		oscalTypes_1_1_3.Export	true	"Export data"
+//	@Success		201				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		409				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export [post]
+func (h *SystemSecurityPlanHandler) CreateImplementedRequirementStatementByComponentExport(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForStatement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.createByComponentExport(ctx, bc)
+}
+
+// UpdateImplementedRequirementStatementByComponentExport godoc
+//
+//	@Summary		Update the export for a statement-level by-component
+//	@Description	Updates the scalar fields of an existing Export for a by-component within a statement. Provided and Responsibilities entries are managed via their own routes.
+//	@Tags			System Security Plans
+//	@Accept			json
+//	@Produce		json
+//	@Param			id				path		string					true	"SSP ID"
+//	@Param			reqId			path		string					true	"Requirement ID"
+//	@Param			stmtId			path		string					true	"Statement ID"
+//	@Param			byComponentId	path		string					true	"By-Component ID"
+//	@Param			export			body		oscalTypes_1_1_3.Export	true	"Export data"
+//	@Success		200				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export [put]
+func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementStatementByComponentExport(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForStatement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.updateByComponentExport(ctx, bc)
+}
+
+// DeleteImplementedRequirementStatementByComponentExport godoc
+//
+//	@Summary		Delete the export for a statement-level by-component
+//	@Description	Deletes the Export (and its Provided/Responsibilities entries) for a by-component within a statement.
+//	@Tags			System Security Plans
+//	@Param			id				path	string	true	"SSP ID"
+//	@Param			reqId			path	string	true	"Requirement ID"
+//	@Param			stmtId			path	string	true	"Statement ID"
+//	@Param			byComponentId	path	string	true	"By-Component ID"
+//	@Success		204				"No Content"
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export [delete]
+func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementStatementByComponentExport(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForStatement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.deleteByComponentExport(ctx, bc)
+}
+
+// findExportForByComponent looks up the (singleton) Export belonging to an
+// already-resolved by-component, writing a 404 if none exists.
+func (h *SystemSecurityPlanHandler) findExportForByComponent(ctx echo.Context, bc *relational.ByComponent) (*relational.Export, bool) {
+	var export relational.Export
+	if err := h.db.Where("by_component_id = ?", bc.ID).First(&export).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			_ = ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("export not found")))
+			return nil, false
+		}
+		_ = ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+		return nil, false
+	}
+	return &export, true
+}
+
+// createByComponentExportProvided creates a Provided entry under an already-resolved
+// by-component's Export.
+func (h *SystemSecurityPlanHandler) createByComponentExportProvided(ctx echo.Context, bc *relational.ByComponent) error {
+	export, ok := h.findExportForByComponent(ctx, bc)
+	if !ok {
+		return nil
+	}
+
+	var oscalProvided oscalTypes_1_1_3.ProvidedControlImplementation
+	if err := ctx.Bind(&oscalProvided); err != nil {
+		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
+	}
+
+	relProvided := &relational.ProvidedControlImplementation{}
+	relProvided.UnmarshalOscal(oscalProvided)
+	relProvided.ExportId = *export.ID
+
+	if err := h.db.Create(relProvided).Error; err != nil {
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	return ctx.JSON(http.StatusCreated, handler.GenericDataResponse[oscalTypes_1_1_3.ProvidedControlImplementation]{Data: *relProvided.MarshalOscal()})
+}
+
+// updateByComponentExportProvided replaces an existing Provided entry under an
+// already-resolved by-component's Export.
+func (h *SystemSecurityPlanHandler) updateByComponentExportProvided(ctx echo.Context, bc *relational.ByComponent) error {
+	export, ok := h.findExportForByComponent(ctx, bc)
+	if !ok {
+		return nil
+	}
+
+	providedIdParam := ctx.Param("providedId")
+	providedID, err := uuid.Parse(providedIdParam)
+	if err != nil {
+		h.sugar.Warnw("Invalid provided id", "providedId", providedIdParam, "error", err)
+		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
+	}
+
+	var existing relational.ProvidedControlImplementation
+	if err := h.db.Where("id = ? AND export_id = ?", providedID, export.ID).First(&existing).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("provided entry not found")))
+		}
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	var oscalProvided oscalTypes_1_1_3.ProvidedControlImplementation
+	if err := ctx.Bind(&oscalProvided); err != nil {
+		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
+	}
+
+	relProvided := &relational.ProvidedControlImplementation{}
+	relProvided.UnmarshalOscal(oscalProvided)
+	relProvided.ID = &providedID
+	relProvided.ExportId = *export.ID
+
+	if err := h.db.Save(relProvided).Error; err != nil {
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	return ctx.JSON(http.StatusOK, handler.GenericDataResponse[oscalTypes_1_1_3.ProvidedControlImplementation]{Data: *relProvided.MarshalOscal()})
+}
+
+// deleteByComponentExportProvided deletes an existing Provided entry under an
+// already-resolved by-component's Export.
+func (h *SystemSecurityPlanHandler) deleteByComponentExportProvided(ctx echo.Context, bc *relational.ByComponent) error {
+	export, ok := h.findExportForByComponent(ctx, bc)
+	if !ok {
+		return nil
+	}
+
+	providedIdParam := ctx.Param("providedId")
+	providedID, err := uuid.Parse(providedIdParam)
+	if err != nil {
+		h.sugar.Warnw("Invalid provided id", "providedId", providedIdParam, "error", err)
+		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
+	}
+
+	result := h.db.Where("id = ? AND export_id = ?", providedID, export.ID).Delete(&relational.ProvidedControlImplementation{})
+	if result.Error != nil {
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(result.Error))
+	}
+	if result.RowsAffected == 0 {
+		return ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("provided entry not found")))
+	}
+
+	return ctx.NoContent(http.StatusNoContent)
+}
+
+// CreateImplementedRequirementByComponentExportProvided godoc
+//
+//	@Summary		Create a provided entry on a control-level by-component's export
+//	@Description	Creates a ProvidedControlImplementation entry under the Export of a by-component within an implemented requirement.
+//	@Tags			System Security Plans
+//	@Accept			json
+//	@Produce		json
+//	@Param			id				path		string											true	"SSP ID"
+//	@Param			reqId			path		string											true	"Requirement ID"
+//	@Param			byComponentId	path		string											true	"By-Component ID"
+//	@Param			provided		body		oscalTypes_1_1_3.ProvidedControlImplementation	true	"Provided data"
+//	@Success		201				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.ProvidedControlImplementation]
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided [post]
+func (h *SystemSecurityPlanHandler) CreateImplementedRequirementByComponentExportProvided(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForRequirement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.createByComponentExportProvided(ctx, bc)
+}
+
+// UpdateImplementedRequirementByComponentExportProvided godoc
+//
+//	@Summary		Update a provided entry on a control-level by-component's export
+//	@Description	Replaces an existing ProvidedControlImplementation entry under the Export of a by-component within an implemented requirement.
+//	@Tags			System Security Plans
+//	@Accept			json
+//	@Produce		json
+//	@Param			id				path		string											true	"SSP ID"
+//	@Param			reqId			path		string											true	"Requirement ID"
+//	@Param			byComponentId	path		string											true	"By-Component ID"
+//	@Param			providedId		path		string											true	"Provided entry ID"
+//	@Param			provided		body		oscalTypes_1_1_3.ProvidedControlImplementation	true	"Provided data"
+//	@Success		200				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.ProvidedControlImplementation]
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided/{providedId} [put]
+func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementByComponentExportProvided(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForRequirement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.updateByComponentExportProvided(ctx, bc)
+}
+
+// DeleteImplementedRequirementByComponentExportProvided godoc
+//
+//	@Summary		Delete a provided entry on a control-level by-component's export
+//	@Description	Deletes an existing ProvidedControlImplementation entry under the Export of a by-component within an implemented requirement.
+//	@Tags			System Security Plans
+//	@Param			id				path	string	true	"SSP ID"
+//	@Param			reqId			path	string	true	"Requirement ID"
+//	@Param			byComponentId	path	string	true	"By-Component ID"
+//	@Param			providedId		path	string	true	"Provided entry ID"
+//	@Success		204				"No Content"
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/provided/{providedId} [delete]
+func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementByComponentExportProvided(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForRequirement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.deleteByComponentExportProvided(ctx, bc)
+}
+
+// CreateImplementedRequirementStatementByComponentExportProvided godoc
+//
+//	@Summary		Create a provided entry on a statement-level by-component's export
+//	@Description	Creates a ProvidedControlImplementation entry under the Export of a by-component within a statement.
+//	@Tags			System Security Plans
+//	@Accept			json
+//	@Produce		json
+//	@Param			id				path		string											true	"SSP ID"
+//	@Param			reqId			path		string											true	"Requirement ID"
+//	@Param			stmtId			path		string											true	"Statement ID"
+//	@Param			byComponentId	path		string											true	"By-Component ID"
+//	@Param			provided		body		oscalTypes_1_1_3.ProvidedControlImplementation	true	"Provided data"
+//	@Success		201				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.ProvidedControlImplementation]
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided [post]
+func (h *SystemSecurityPlanHandler) CreateImplementedRequirementStatementByComponentExportProvided(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForStatement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.createByComponentExportProvided(ctx, bc)
+}
+
+// UpdateImplementedRequirementStatementByComponentExportProvided godoc
+//
+//	@Summary		Update a provided entry on a statement-level by-component's export
+//	@Description	Replaces an existing ProvidedControlImplementation entry under the Export of a by-component within a statement.
+//	@Tags			System Security Plans
+//	@Accept			json
+//	@Produce		json
+//	@Param			id				path		string											true	"SSP ID"
+//	@Param			reqId			path		string											true	"Requirement ID"
+//	@Param			stmtId			path		string											true	"Statement ID"
+//	@Param			byComponentId	path		string											true	"By-Component ID"
+//	@Param			providedId		path		string											true	"Provided entry ID"
+//	@Param			provided		body		oscalTypes_1_1_3.ProvidedControlImplementation	true	"Provided data"
+//	@Success		200				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.ProvidedControlImplementation]
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided/{providedId} [put]
+func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementStatementByComponentExportProvided(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForStatement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.updateByComponentExportProvided(ctx, bc)
+}
+
+// DeleteImplementedRequirementStatementByComponentExportProvided godoc
+//
+//	@Summary		Delete a provided entry on a statement-level by-component's export
+//	@Description	Deletes an existing ProvidedControlImplementation entry under the Export of a by-component within a statement.
+//	@Tags			System Security Plans
+//	@Param			id				path	string	true	"SSP ID"
+//	@Param			reqId			path	string	true	"Requirement ID"
+//	@Param			stmtId			path	string	true	"Statement ID"
+//	@Param			byComponentId	path	string	true	"By-Component ID"
+//	@Param			providedId		path	string	true	"Provided entry ID"
+//	@Success		204				"No Content"
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/provided/{providedId} [delete]
+func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementStatementByComponentExportProvided(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForStatement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.deleteByComponentExportProvided(ctx, bc)
+}
+
+// createByComponentExportResponsibility creates a Responsibility entry under an
+// already-resolved by-component's Export.
+func (h *SystemSecurityPlanHandler) createByComponentExportResponsibility(ctx echo.Context, bc *relational.ByComponent) error {
+	export, ok := h.findExportForByComponent(ctx, bc)
+	if !ok {
+		return nil
+	}
+
+	var oscalResponsibility oscalTypes_1_1_3.ControlImplementationResponsibility
+	if err := ctx.Bind(&oscalResponsibility); err != nil {
+		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
+	}
+
+	relResponsibility := &relational.ControlImplementationResponsibility{}
+	relResponsibility.UnmarshalOscal(oscalResponsibility)
+	relResponsibility.ExportId = *export.ID
+
+	if err := h.db.Create(relResponsibility).Error; err != nil {
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	return ctx.JSON(http.StatusCreated, handler.GenericDataResponse[oscalTypes_1_1_3.ControlImplementationResponsibility]{Data: *relResponsibility.MarshalOscal()})
+}
+
+// updateByComponentExportResponsibility replaces an existing Responsibility entry
+// under an already-resolved by-component's Export.
+func (h *SystemSecurityPlanHandler) updateByComponentExportResponsibility(ctx echo.Context, bc *relational.ByComponent) error {
+	export, ok := h.findExportForByComponent(ctx, bc)
+	if !ok {
+		return nil
+	}
+
+	responsibilityIdParam := ctx.Param("responsibilityId")
+	responsibilityID, err := uuid.Parse(responsibilityIdParam)
+	if err != nil {
+		h.sugar.Warnw("Invalid responsibility id", "responsibilityId", responsibilityIdParam, "error", err)
+		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
+	}
+
+	var existing relational.ControlImplementationResponsibility
+	if err := h.db.Where("id = ? AND export_id = ?", responsibilityID, export.ID).First(&existing).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("responsibility entry not found")))
+		}
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	var oscalResponsibility oscalTypes_1_1_3.ControlImplementationResponsibility
+	if err := ctx.Bind(&oscalResponsibility); err != nil {
+		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
+	}
+
+	relResponsibility := &relational.ControlImplementationResponsibility{}
+	relResponsibility.UnmarshalOscal(oscalResponsibility)
+	relResponsibility.ID = &responsibilityID
+	relResponsibility.ExportId = *export.ID
+
+	if err := h.db.Save(relResponsibility).Error; err != nil {
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
+	return ctx.JSON(http.StatusOK, handler.GenericDataResponse[oscalTypes_1_1_3.ControlImplementationResponsibility]{Data: *relResponsibility.MarshalOscal()})
+}
+
+// deleteByComponentExportResponsibility deletes an existing Responsibility entry
+// under an already-resolved by-component's Export.
+func (h *SystemSecurityPlanHandler) deleteByComponentExportResponsibility(ctx echo.Context, bc *relational.ByComponent) error {
+	export, ok := h.findExportForByComponent(ctx, bc)
+	if !ok {
+		return nil
+	}
+
+	responsibilityIdParam := ctx.Param("responsibilityId")
+	responsibilityID, err := uuid.Parse(responsibilityIdParam)
+	if err != nil {
+		h.sugar.Warnw("Invalid responsibility id", "responsibilityId", responsibilityIdParam, "error", err)
+		return ctx.JSON(http.StatusBadRequest, api.NewError(err))
+	}
+
+	result := h.db.Where("id = ? AND export_id = ?", responsibilityID, export.ID).Delete(&relational.ControlImplementationResponsibility{})
+	if result.Error != nil {
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(result.Error))
+	}
+	if result.RowsAffected == 0 {
+		return ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("responsibility entry not found")))
+	}
+
+	return ctx.NoContent(http.StatusNoContent)
+}
+
+// CreateImplementedRequirementByComponentExportResponsibility godoc
+//
+//	@Summary		Create a responsibility entry on a control-level by-component's export
+//	@Description	Creates a ControlImplementationResponsibility entry under the Export of a by-component within an implemented requirement.
+//	@Tags			System Security Plans
+//	@Accept			json
+//	@Produce		json
+//	@Param			id				path		string													true	"SSP ID"
+//	@Param			reqId			path		string													true	"Requirement ID"
+//	@Param			byComponentId	path		string													true	"By-Component ID"
+//	@Param			responsibility	body		oscalTypes_1_1_3.ControlImplementationResponsibility	true	"Responsibility data"
+//	@Success		201				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.ControlImplementationResponsibility]
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities [post]
+func (h *SystemSecurityPlanHandler) CreateImplementedRequirementByComponentExportResponsibility(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForRequirement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.createByComponentExportResponsibility(ctx, bc)
+}
+
+// UpdateImplementedRequirementByComponentExportResponsibility godoc
+//
+//	@Summary		Update a responsibility entry on a control-level by-component's export
+//	@Description	Replaces an existing ControlImplementationResponsibility entry under the Export of a by-component within an implemented requirement.
+//	@Tags			System Security Plans
+//	@Accept			json
+//	@Produce		json
+//	@Param			id					path		string													true	"SSP ID"
+//	@Param			reqId				path		string													true	"Requirement ID"
+//	@Param			byComponentId		path		string													true	"By-Component ID"
+//	@Param			responsibilityId	path		string													true	"Responsibility entry ID"
+//	@Param			responsibility		body		oscalTypes_1_1_3.ControlImplementationResponsibility	true	"Responsibility data"
+//	@Success		200					{object}	handler.GenericDataResponse[oscalTypes_1_1_3.ControlImplementationResponsibility]
+//	@Failure		400					{object}	api.Error
+//	@Failure		404					{object}	api.Error
+//	@Failure		500					{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId} [put]
+func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementByComponentExportResponsibility(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForRequirement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.updateByComponentExportResponsibility(ctx, bc)
+}
+
+// DeleteImplementedRequirementByComponentExportResponsibility godoc
+//
+//	@Summary		Delete a responsibility entry on a control-level by-component's export
+//	@Description	Deletes an existing ControlImplementationResponsibility entry under the Export of a by-component within an implemented requirement.
+//	@Tags			System Security Plans
+//	@Param			id					path	string	true	"SSP ID"
+//	@Param			reqId				path	string	true	"Requirement ID"
+//	@Param			byComponentId		path	string	true	"By-Component ID"
+//	@Param			responsibilityId	path	string	true	"Responsibility entry ID"
+//	@Success		204					"No Content"
+//	@Failure		400					{object}	api.Error
+//	@Failure		404					{object}	api.Error
+//	@Failure		500					{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId} [delete]
+func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementByComponentExportResponsibility(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForRequirement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.deleteByComponentExportResponsibility(ctx, bc)
+}
+
+// CreateImplementedRequirementStatementByComponentExportResponsibility godoc
+//
+//	@Summary		Create a responsibility entry on a statement-level by-component's export
+//	@Description	Creates a ControlImplementationResponsibility entry under the Export of a by-component within a statement.
+//	@Tags			System Security Plans
+//	@Accept			json
+//	@Produce		json
+//	@Param			id				path		string													true	"SSP ID"
+//	@Param			reqId			path		string													true	"Requirement ID"
+//	@Param			stmtId			path		string													true	"Statement ID"
+//	@Param			byComponentId	path		string													true	"By-Component ID"
+//	@Param			responsibility	body		oscalTypes_1_1_3.ControlImplementationResponsibility	true	"Responsibility data"
+//	@Success		201				{object}	handler.GenericDataResponse[oscalTypes_1_1_3.ControlImplementationResponsibility]
+//	@Failure		400				{object}	api.Error
+//	@Failure		404				{object}	api.Error
+//	@Failure		500				{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities [post]
+func (h *SystemSecurityPlanHandler) CreateImplementedRequirementStatementByComponentExportResponsibility(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForStatement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.createByComponentExportResponsibility(ctx, bc)
+}
+
+// UpdateImplementedRequirementStatementByComponentExportResponsibility godoc
+//
+//	@Summary		Update a responsibility entry on a statement-level by-component's export
+//	@Description	Replaces an existing ControlImplementationResponsibility entry under the Export of a by-component within a statement.
+//	@Tags			System Security Plans
+//	@Accept			json
+//	@Produce		json
+//	@Param			id					path		string													true	"SSP ID"
+//	@Param			reqId				path		string													true	"Requirement ID"
+//	@Param			stmtId				path		string													true	"Statement ID"
+//	@Param			byComponentId		path		string													true	"By-Component ID"
+//	@Param			responsibilityId	path		string													true	"Responsibility entry ID"
+//	@Param			responsibility		body		oscalTypes_1_1_3.ControlImplementationResponsibility	true	"Responsibility data"
+//	@Success		200					{object}	handler.GenericDataResponse[oscalTypes_1_1_3.ControlImplementationResponsibility]
+//	@Failure		400					{object}	api.Error
+//	@Failure		404					{object}	api.Error
+//	@Failure		500					{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId} [put]
+func (h *SystemSecurityPlanHandler) UpdateImplementedRequirementStatementByComponentExportResponsibility(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForStatement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.updateByComponentExportResponsibility(ctx, bc)
+}
+
+// DeleteImplementedRequirementStatementByComponentExportResponsibility godoc
+//
+//	@Summary		Delete a responsibility entry on a statement-level by-component's export
+//	@Description	Deletes an existing ControlImplementationResponsibility entry under the Export of a by-component within a statement.
+//	@Tags			System Security Plans
+//	@Param			id					path	string	true	"SSP ID"
+//	@Param			reqId				path	string	true	"Requirement ID"
+//	@Param			stmtId				path	string	true	"Statement ID"
+//	@Param			byComponentId		path	string	true	"By-Component ID"
+//	@Param			responsibilityId	path	string	true	"Responsibility entry ID"
+//	@Success		204					"No Content"
+//	@Failure		400					{object}	api.Error
+//	@Failure		404					{object}	api.Error
+//	@Failure		500					{object}	api.Error
+//	@Router			/oscal/system-security-plans/{id}/control-implementation/implemented-requirements/{reqId}/statements/{stmtId}/by-components/{byComponentId}/export/responsibilities/{responsibilityId} [delete]
+func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementStatementByComponentExportResponsibility(ctx echo.Context) error {
+	bc, ok := h.resolveByComponentForStatement(ctx)
+	if !ok {
+		return nil
+	}
+	return h.deleteByComponentExportResponsibility(ctx, bc)
 }
 
 // extractControlIDsFromProfile resolves a profile and extracts all control IDs

--- a/internal/api/handler/oscal/system_security_plans_test.go
+++ b/internal/api/handler/oscal/system_security_plans_test.go
@@ -1185,6 +1185,578 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateByComponentInvalid
 	suite.Equal(http.StatusCreated, resp.Code)
 }
 
+// setupSSPWithByComponents creates a basic SSP with one implemented requirement that has
+// both a control-level by-component and a statement with a statement-level by-component,
+// both referencing the SSP's first system component. It returns the running server and the
+// IDs needed to exercise by-component-scoped routes.
+func (suite *SystemSecurityPlanApiIntegrationSuite) setupSSPWithByComponents() (server *api.Server, sspUUID, reqUUID, stmtUUID, controlBCUUID, stmtBCUUID string) {
+	logConf := zap.NewDevelopmentConfig()
+	logConf.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
+	logger, _ := logConf.Build()
+
+	err := suite.Migrator.Refresh()
+	suite.Require().NoError(err)
+
+	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
+	server = api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
+	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil, nil)
+
+	ssp := suite.createBasicSSP()
+	componentUuid := ssp.SystemImplementation.Components[0].UUID
+	ssp.ControlImplementation.ImplementedRequirements[0].Statements = nil
+
+	req := suite.createRequest("POST", "/api/oscal/system-security-plans", ssp)
+	resp := httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusCreated, resp.Code)
+
+	controlBCUUID = uuid.New().String()
+	stmtBCUUID = uuid.New().String()
+
+	implementedReq := oscalTypes_1_1_3.ImplementedRequirement{
+		UUID:      uuid.New().String(),
+		ControlId: "ac-1",
+		ByComponents: &[]oscalTypes_1_1_3.ByComponent{
+			{
+				UUID:          controlBCUUID,
+				ComponentUuid: componentUuid,
+				Description:   "Control-level by component",
+			},
+		},
+		Statements: &[]oscalTypes_1_1_3.Statement{
+			{
+				UUID:        uuid.New().String(),
+				StatementId: "ac-1_stmt.a",
+				ByComponents: &[]oscalTypes_1_1_3.ByComponent{
+					{
+						UUID:          stmtBCUUID,
+						ComponentUuid: componentUuid,
+						Description:   "Statement-level by component",
+					},
+				},
+			},
+		},
+	}
+
+	req = suite.createRequest("POST", fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements", ssp.UUID), implementedReq)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusCreated, resp.Code)
+
+	var createResponse handler.GenericDataResponse[oscalTypes_1_1_3.ImplementedRequirement]
+	err = json.Unmarshal(resp.Body.Bytes(), &createResponse)
+	suite.Require().NoError(err)
+
+	requirement := createResponse.Data
+	suite.Require().NotNil(requirement.Statements)
+	suite.Require().NotEmpty(*requirement.Statements)
+
+	return server, ssp.UUID, requirement.UUID, (*requirement.Statements)[0].UUID, controlBCUUID, stmtBCUUID
+}
+
+// exerciseByComponentExportCRUD drives the full Export CRUD lifecycle (get-missing,
+// create, create-conflict, get, update, delete, get-missing-again, delete-missing) against
+// the given by-component's export path, shared between the control- and statement-level
+// tests below since the handler logic is identical once the by-component is resolved.
+func (suite *SystemSecurityPlanApiIntegrationSuite) exerciseByComponentExportCRUD(server *api.Server, exportPath string) {
+	// GET before creation: 404
+	req := suite.createRequest("GET", exportPath, nil)
+	resp := httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Equal(http.StatusNotFound, resp.Code)
+
+	// POST creates the export, including nested provided/responsibilities
+	providedUUID := uuid.New().String()
+	newExport := oscalTypes_1_1_3.Export{
+		Description: "Export description",
+		Remarks:     "Export remarks",
+		Provided: &[]oscalTypes_1_1_3.ProvidedControlImplementation{
+			{
+				UUID:        providedUUID,
+				Description: "Provided description",
+			},
+		},
+		Responsibilities: &[]oscalTypes_1_1_3.ControlImplementationResponsibility{
+			{
+				UUID:         uuid.New().String(),
+				Description:  "Responsibility description",
+				ProvidedUuid: providedUUID,
+			},
+		},
+	}
+	req = suite.createRequest("POST", exportPath, newExport)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusCreated, resp.Code)
+
+	var createResponse handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &createResponse))
+	suite.Equal("Export description", createResponse.Data.Description)
+	suite.Require().NotNil(createResponse.Data.Provided)
+	suite.Len(*createResponse.Data.Provided, 1)
+	suite.Require().NotNil(createResponse.Data.Responsibilities)
+	suite.Len(*createResponse.Data.Responsibilities, 1)
+
+	// POST again: 409 conflict, export already exists
+	req = suite.createRequest("POST", exportPath, newExport)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Equal(http.StatusConflict, resp.Code)
+
+	// GET returns the created export
+	req = suite.createRequest("GET", exportPath, nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusOK, resp.Code)
+
+	var getResponse handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &getResponse))
+	suite.Equal("Export description", getResponse.Data.Description)
+
+	// PUT rejects a payload carrying nested provided/responsibilities; those are
+	// managed via their own routes, not by replacing the export wholesale.
+	rejectedExport := oscalTypes_1_1_3.Export{
+		Description: "Should be rejected",
+		Provided: &[]oscalTypes_1_1_3.ProvidedControlImplementation{
+			{UUID: uuid.New().String(), Description: "Should not be applied"},
+		},
+	}
+	req = suite.createRequest("PUT", exportPath, rejectedExport)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Equal(http.StatusBadRequest, resp.Code)
+
+	// PUT updates scalar fields only.
+	updatedExport := oscalTypes_1_1_3.Export{
+		Description: "Updated export description",
+		Remarks:     "Updated export remarks",
+	}
+	req = suite.createRequest("PUT", exportPath, updatedExport)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusOK, resp.Code)
+
+	var updateResponse handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &updateResponse))
+	suite.Equal("Updated export description", updateResponse.Data.Description)
+	suite.Equal("Updated export remarks", updateResponse.Data.Remarks)
+	suite.Require().NotNil(updateResponse.Data.Provided)
+	suite.Len(*updateResponse.Data.Provided, 1)
+	suite.Require().NotNil(updateResponse.Data.Responsibilities)
+	suite.Len(*updateResponse.Data.Responsibilities, 1)
+
+	// DELETE removes the export
+	req = suite.createRequest("DELETE", exportPath, nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Equal(http.StatusNoContent, resp.Code)
+
+	// GET after deletion: 404
+	req = suite.createRequest("GET", exportPath, nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Equal(http.StatusNotFound, resp.Code)
+
+	// DELETE again: 404
+	req = suite.createRequest("DELETE", exportPath, nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Equal(http.StatusNotFound, resp.Code)
+}
+
+func (suite *SystemSecurityPlanApiIntegrationSuite) TestByComponentExportCRUD_ControlLevel() {
+	server, sspUUID, reqUUID, _, controlBCUUID, _ := suite.setupSSPWithByComponents()
+	exportPath := fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/by-components/%s/export",
+		sspUUID, reqUUID, controlBCUUID)
+	suite.exerciseByComponentExportCRUD(server, exportPath)
+}
+
+func (suite *SystemSecurityPlanApiIntegrationSuite) TestByComponentExportCRUD_StatementLevel() {
+	server, sspUUID, reqUUID, stmtUUID, _, stmtBCUUID := suite.setupSSPWithByComponents()
+	exportPath := fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/statements/%s/by-components/%s/export",
+		sspUUID, reqUUID, stmtUUID, stmtBCUUID)
+	suite.exerciseByComponentExportCRUD(server, exportPath)
+}
+
+// setupSSPWithExports extends setupSSPWithByComponents by also creating an empty Export
+// on both the control-level and statement-level by-components, since Provided and
+// Responsibility entries nest under an existing Export.
+func (suite *SystemSecurityPlanApiIntegrationSuite) setupSSPWithExports() (server *api.Server, controlExportPath, stmtExportPath string) {
+	server, sspUUID, reqUUID, stmtUUID, controlBCUUID, stmtBCUUID := suite.setupSSPWithByComponents()
+	controlExportPath = fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/by-components/%s/export",
+		sspUUID, reqUUID, controlBCUUID)
+	stmtExportPath = fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/statements/%s/by-components/%s/export",
+		sspUUID, reqUUID, stmtUUID, stmtBCUUID)
+
+	for _, path := range []string{controlExportPath, stmtExportPath} {
+		req := suite.createRequest("POST", path, oscalTypes_1_1_3.Export{Description: "export"})
+		resp := httptest.NewRecorder()
+		server.E().ServeHTTP(resp, req)
+		suite.Require().Equal(http.StatusCreated, resp.Code)
+	}
+
+	return server, controlExportPath, stmtExportPath
+}
+
+// exerciseByComponentExportProvidedCRUD drives the full CRUD lifecycle for a single
+// provided entry against the given export path, shared between the control- and
+// statement-level tests below.
+func (suite *SystemSecurityPlanApiIntegrationSuite) exerciseByComponentExportProvidedCRUD(server *api.Server, exportPath string) {
+	providedPath := exportPath + "/provided"
+
+	newProvided := oscalTypes_1_1_3.ProvidedControlImplementation{
+		UUID:        uuid.New().String(),
+		Description: "Provided description",
+	}
+	req := suite.createRequest("POST", providedPath, newProvided)
+	resp := httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusCreated, resp.Code)
+
+	var createResponse handler.GenericDataResponse[oscalTypes_1_1_3.ProvidedControlImplementation]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &createResponse))
+	suite.Equal(newProvided.UUID, createResponse.Data.UUID)
+	suite.Equal("Provided description", createResponse.Data.Description)
+
+	itemPath := fmt.Sprintf("%s/%s", providedPath, newProvided.UUID)
+
+	updatedProvided := oscalTypes_1_1_3.ProvidedControlImplementation{
+		UUID:        newProvided.UUID,
+		Description: "Updated provided description",
+		Remarks:     "Updated remarks",
+	}
+	req = suite.createRequest("PUT", itemPath, updatedProvided)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusOK, resp.Code)
+
+	var updateResponse handler.GenericDataResponse[oscalTypes_1_1_3.ProvidedControlImplementation]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &updateResponse))
+	suite.Equal("Updated provided description", updateResponse.Data.Description)
+	suite.Equal("Updated remarks", updateResponse.Data.Remarks)
+
+	// The parent export now reflects the updated provided entry.
+	var getExportResponse handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+	req = suite.createRequest("GET", exportPath, nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusOK, resp.Code)
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &getExportResponse))
+	suite.Require().NotNil(getExportResponse.Data.Provided)
+	suite.Len(*getExportResponse.Data.Provided, 1)
+	suite.Equal("Updated provided description", (*getExportResponse.Data.Provided)[0].Description)
+
+	// DELETE removes the entry.
+	req = suite.createRequest("DELETE", itemPath, nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Equal(http.StatusNoContent, resp.Code)
+
+	// DELETE again: 404.
+	req = suite.createRequest("DELETE", itemPath, nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Equal(http.StatusNotFound, resp.Code)
+
+	// PUT on a missing entry: 404.
+	req = suite.createRequest("PUT", itemPath, updatedProvided)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Equal(http.StatusNotFound, resp.Code)
+
+	// The parent export no longer lists the deleted provided entry.
+	req = suite.createRequest("GET", exportPath, nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusOK, resp.Code)
+	var finalExportResponse handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &finalExportResponse))
+	if finalExportResponse.Data.Provided != nil {
+		suite.Empty(*finalExportResponse.Data.Provided)
+	}
+}
+
+func (suite *SystemSecurityPlanApiIntegrationSuite) TestByComponentExportProvidedCRUD_ControlLevel() {
+	server, controlExportPath, _ := suite.setupSSPWithExports()
+	suite.exerciseByComponentExportProvidedCRUD(server, controlExportPath)
+}
+
+func (suite *SystemSecurityPlanApiIntegrationSuite) TestByComponentExportProvidedCRUD_StatementLevel() {
+	server, _, stmtExportPath := suite.setupSSPWithExports()
+	suite.exerciseByComponentExportProvidedCRUD(server, stmtExportPath)
+}
+
+// exerciseByComponentExportResponsibilityCRUD drives the full CRUD lifecycle for a single
+// responsibility entry against the given export path, shared between the control- and
+// statement-level tests below.
+func (suite *SystemSecurityPlanApiIntegrationSuite) exerciseByComponentExportResponsibilityCRUD(server *api.Server, exportPath string) {
+	responsibilityPath := exportPath + "/responsibilities"
+
+	newResponsibility := oscalTypes_1_1_3.ControlImplementationResponsibility{
+		UUID:        uuid.New().String(),
+		Description: "Responsibility description",
+	}
+	req := suite.createRequest("POST", responsibilityPath, newResponsibility)
+	resp := httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusCreated, resp.Code)
+
+	var createResponse handler.GenericDataResponse[oscalTypes_1_1_3.ControlImplementationResponsibility]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &createResponse))
+	suite.Equal(newResponsibility.UUID, createResponse.Data.UUID)
+	suite.Equal("Responsibility description", createResponse.Data.Description)
+
+	itemPath := fmt.Sprintf("%s/%s", responsibilityPath, newResponsibility.UUID)
+
+	updatedResponsibility := oscalTypes_1_1_3.ControlImplementationResponsibility{
+		UUID:        newResponsibility.UUID,
+		Description: "Updated responsibility description",
+		Remarks:     "Updated remarks",
+	}
+	req = suite.createRequest("PUT", itemPath, updatedResponsibility)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusOK, resp.Code)
+
+	var updateResponse handler.GenericDataResponse[oscalTypes_1_1_3.ControlImplementationResponsibility]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &updateResponse))
+	suite.Equal("Updated responsibility description", updateResponse.Data.Description)
+	suite.Equal("Updated remarks", updateResponse.Data.Remarks)
+
+	// The parent export now reflects the updated responsibility entry.
+	var getExportResponse handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+	req = suite.createRequest("GET", exportPath, nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusOK, resp.Code)
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &getExportResponse))
+	suite.Require().NotNil(getExportResponse.Data.Responsibilities)
+	suite.Len(*getExportResponse.Data.Responsibilities, 1)
+	suite.Equal("Updated responsibility description", (*getExportResponse.Data.Responsibilities)[0].Description)
+
+	// DELETE removes the entry.
+	req = suite.createRequest("DELETE", itemPath, nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Equal(http.StatusNoContent, resp.Code)
+
+	// DELETE again: 404.
+	req = suite.createRequest("DELETE", itemPath, nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Equal(http.StatusNotFound, resp.Code)
+
+	// PUT on a missing entry: 404.
+	req = suite.createRequest("PUT", itemPath, updatedResponsibility)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Equal(http.StatusNotFound, resp.Code)
+
+	// The parent export no longer lists the deleted responsibility entry.
+	req = suite.createRequest("GET", exportPath, nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusOK, resp.Code)
+	var finalExportResponse handler.GenericDataResponse[oscalTypes_1_1_3.Export]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &finalExportResponse))
+	if finalExportResponse.Data.Responsibilities != nil {
+		suite.Empty(*finalExportResponse.Data.Responsibilities)
+	}
+}
+
+func (suite *SystemSecurityPlanApiIntegrationSuite) TestByComponentExportResponsibilityCRUD_ControlLevel() {
+	server, controlExportPath, _ := suite.setupSSPWithExports()
+	suite.exerciseByComponentExportResponsibilityCRUD(server, controlExportPath)
+}
+
+func (suite *SystemSecurityPlanApiIntegrationSuite) TestByComponentExportResponsibilityCRUD_StatementLevel() {
+	server, _, stmtExportPath := suite.setupSSPWithExports()
+	suite.exerciseByComponentExportResponsibilityCRUD(server, stmtExportPath)
+}
+
+// TestSSPExportRoundTrip authors Export/Provided/Responsibility data on both a
+// control-level and a statement-level by-component (plus Inherited/Satisfied entries with
+// unequal counts, to exercise the task 001 marshalling fix live against a full SSP), fetches
+// the full SSP (the same MarshalOscal() path used by `ccf oscal export`), and then re-imports
+// that document by unmarshalling it back into a fresh relational model and re-marshalling —
+// asserting no loss of the provided/responsibility/satisfied data through that round trip.
+func (suite *SystemSecurityPlanApiIntegrationSuite) TestSSPExportRoundTrip() {
+	logConf := zap.NewDevelopmentConfig()
+	logConf.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
+	logger, _ := logConf.Build()
+
+	err := suite.Migrator.Refresh()
+	suite.Require().NoError(err)
+
+	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
+	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
+	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil, nil)
+
+	ssp := suite.createBasicSSP()
+	componentUuid := ssp.SystemImplementation.Components[0].UUID
+	ssp.ControlImplementation.ImplementedRequirements[0].Statements = nil
+
+	req := suite.createRequest("POST", "/api/oscal/system-security-plans", ssp)
+	resp := httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusCreated, resp.Code)
+
+	controlBCUUID := uuid.New().String()
+	stmtBCUUID := uuid.New().String()
+
+	implementedReq := oscalTypes_1_1_3.ImplementedRequirement{
+		UUID:      uuid.New().String(),
+		ControlId: "ac-1",
+		ByComponents: &[]oscalTypes_1_1_3.ByComponent{
+			{
+				UUID:          controlBCUUID,
+				ComponentUuid: componentUuid,
+				Description:   "Control-level by component",
+				Inherited: &[]oscalTypes_1_1_3.InheritedControlImplementation{
+					{UUID: uuid.New().String(), Description: "Inherited from upstream SSP"},
+				},
+				Satisfied: &[]oscalTypes_1_1_3.SatisfiedControlImplementationResponsibility{
+					{UUID: uuid.New().String(), Description: "Satisfied 1"},
+					{UUID: uuid.New().String(), Description: "Satisfied 2"},
+					{UUID: uuid.New().String(), Description: "Satisfied 3"},
+				},
+			},
+		},
+		Statements: &[]oscalTypes_1_1_3.Statement{
+			{
+				UUID:        uuid.New().String(),
+				StatementId: "ac-1_stmt.a",
+				ByComponents: &[]oscalTypes_1_1_3.ByComponent{
+					{
+						UUID:          stmtBCUUID,
+						ComponentUuid: componentUuid,
+						Description:   "Statement-level by component",
+					},
+				},
+			},
+		},
+	}
+
+	req = suite.createRequest("POST", fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements", ssp.UUID), implementedReq)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusCreated, resp.Code)
+
+	var createIRResponse handler.GenericDataResponse[oscalTypes_1_1_3.ImplementedRequirement]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &createIRResponse))
+	requirement := createIRResponse.Data
+	suite.Require().NotNil(requirement.Statements)
+	suite.Require().NotEmpty(*requirement.Statements)
+	stmtUUID := (*requirement.Statements)[0].UUID
+
+	controlExportPath := fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/by-components/%s/export",
+		ssp.UUID, requirement.UUID, controlBCUUID)
+	stmtExportPath := fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/statements/%s/by-components/%s/export",
+		ssp.UUID, requirement.UUID, stmtUUID, stmtBCUUID)
+
+	// Author an Export with one Provided and one Responsibility entry on both levels.
+	for _, exportPath := range []string{controlExportPath, stmtExportPath} {
+		providedUUID := uuid.New().String()
+
+		req = suite.createRequest("POST", exportPath, oscalTypes_1_1_3.Export{Description: "Export description", Remarks: "Export remarks"})
+		resp = httptest.NewRecorder()
+		server.E().ServeHTTP(resp, req)
+		suite.Require().Equal(http.StatusCreated, resp.Code)
+
+		req = suite.createRequest("POST", exportPath+"/provided", oscalTypes_1_1_3.ProvidedControlImplementation{
+			UUID:        providedUUID,
+			Description: "Provided description",
+		})
+		resp = httptest.NewRecorder()
+		server.E().ServeHTTP(resp, req)
+		suite.Require().Equal(http.StatusCreated, resp.Code)
+
+		req = suite.createRequest("POST", exportPath+"/responsibilities", oscalTypes_1_1_3.ControlImplementationResponsibility{
+			UUID:         uuid.New().String(),
+			Description:  "Responsibility description",
+			ProvidedUuid: providedUUID,
+		})
+		resp = httptest.NewRecorder()
+		server.E().ServeHTTP(resp, req)
+		suite.Require().Equal(http.StatusCreated, resp.Code)
+	}
+
+	// Fetch the full SSP — the same MarshalOscal() path `ccf oscal export` uses.
+	req = suite.createRequest("GET", fmt.Sprintf("/api/oscal/system-security-plans/%s/full", ssp.UUID), nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusOK, resp.Code)
+
+	var fullResponse handler.GenericDataResponse[oscalTypes_1_1_3.SystemSecurityPlan]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &fullResponse))
+	exported := fullResponse.Data
+
+	var exportedReq *oscalTypes_1_1_3.ImplementedRequirement
+	for i := range exported.ControlImplementation.ImplementedRequirements {
+		if exported.ControlImplementation.ImplementedRequirements[i].UUID == requirement.UUID {
+			exportedReq = &exported.ControlImplementation.ImplementedRequirements[i]
+			break
+		}
+	}
+	suite.Require().NotNil(exportedReq)
+	suite.Require().NotNil(exportedReq.ByComponents)
+	suite.Require().NotEmpty(*exportedReq.ByComponents)
+	exportedControlBC := (*exportedReq.ByComponents)[0]
+
+	// The task 001 fix: 3 satisfied vs 1 inherited must marshal correctly end-to-end.
+	suite.Require().NotNil(exportedControlBC.Satisfied)
+	suite.Len(*exportedControlBC.Satisfied, 3)
+	suite.Require().NotNil(exportedControlBC.Inherited)
+	suite.Len(*exportedControlBC.Inherited, 1)
+
+	suite.Require().NotNil(exportedControlBC.Export)
+	suite.Require().NotNil(exportedControlBC.Export.Provided)
+	suite.Len(*exportedControlBC.Export.Provided, 1)
+	suite.Require().NotNil(exportedControlBC.Export.Responsibilities)
+	suite.Len(*exportedControlBC.Export.Responsibilities, 1)
+
+	suite.Require().NotNil(exportedReq.Statements)
+	suite.Require().NotEmpty(*exportedReq.Statements)
+	exportedStmt := (*exportedReq.Statements)[0]
+	suite.Require().NotNil(exportedStmt.ByComponents)
+	suite.Require().NotEmpty(*exportedStmt.ByComponents)
+	exportedStmtBC := (*exportedStmt.ByComponents)[0]
+	suite.Require().NotNil(exportedStmtBC.Export)
+	suite.Require().NotNil(exportedStmtBC.Export.Provided)
+	suite.Len(*exportedStmtBC.Export.Provided, 1)
+	suite.Require().NotNil(exportedStmtBC.Export.Responsibilities)
+	suite.Len(*exportedStmtBC.Export.Responsibilities, 1)
+
+	// Re-import: unmarshal the exported OSCAL document back into a fresh relational model
+	// and re-marshal it, then assert no loss of provided/responsibility/satisfied data.
+	reimported := &relational.SystemSecurityPlan{}
+	reimported.UnmarshalOscal(exported)
+	reexported := reimported.MarshalOscal()
+
+	var reexportedReq *oscalTypes_1_1_3.ImplementedRequirement
+	for i := range reexported.ControlImplementation.ImplementedRequirements {
+		if reexported.ControlImplementation.ImplementedRequirements[i].UUID == requirement.UUID {
+			reexportedReq = &reexported.ControlImplementation.ImplementedRequirements[i]
+			break
+		}
+	}
+	suite.Require().NotNil(reexportedReq)
+	suite.Require().NotNil(reexportedReq.ByComponents)
+	reexportedControlBC := (*reexportedReq.ByComponents)[0]
+
+	suite.Equal(*exportedControlBC.Satisfied, *reexportedControlBC.Satisfied)
+	suite.Equal(*exportedControlBC.Inherited, *reexportedControlBC.Inherited)
+	suite.Equal(*exportedControlBC.Export.Provided, *reexportedControlBC.Export.Provided)
+	suite.Equal(*exportedControlBC.Export.Responsibilities, *reexportedControlBC.Export.Responsibilities)
+
+	suite.Require().NotNil(reexportedReq.Statements)
+	reexportedStmtBC := (*(*reexportedReq.Statements)[0].ByComponents)[0]
+	suite.Equal(*exportedStmtBC.Export.Provided, *reexportedStmtBC.Export.Provided)
+	suite.Equal(*exportedStmtBC.Export.Responsibilities, *reexportedStmtBC.Export.Responsibilities)
+}
+
 // Test updating a statement with invalid IDs
 func (suite *SystemSecurityPlanApiIntegrationSuite) TestUpdateImplementedRequirementStatementInvalidIDs() {
 	logConf := zap.NewDevelopmentConfig()

--- a/internal/api/handler/oscal/system_security_plans_test.go
+++ b/internal/api/handler/oscal/system_security_plans_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -1379,6 +1380,62 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestByComponentExportCRUD_St
 	suite.exerciseByComponentExportCRUD(server, exportPath)
 }
 
+// TestByComponentExportCreate_ConcurrentRequestsDoNotDuplicate fires many concurrent
+// POSTs at the same by-component's export path and asserts exactly one succeeds (201)
+// while every other request is rejected with 409 — never two 201s (which would mean two
+// Export rows for the same by-component) and never a 500. This exercises the advisory
+// lock in createByComponentExport that closes the TOCTOU race between the existence
+// check and the insert (Export.ByComponentId has no unique DB constraint).
+func (suite *SystemSecurityPlanApiIntegrationSuite) TestByComponentExportCreate_ConcurrentRequestsDoNotDuplicate() {
+	server, sspUUID, reqUUID, _, controlBCUUID, _ := suite.setupSSPWithByComponents()
+	exportPath := fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/by-components/%s/export",
+		sspUUID, reqUUID, controlBCUUID)
+
+	const concurrency = 30
+	codes := make([]int, concurrency)
+	requests := make([]*http.Request, concurrency)
+	for i := range requests {
+		requests[i] = suite.createRequest("POST", exportPath, oscalTypes_1_1_3.Export{Description: "concurrent export"})
+	}
+
+	start := make(chan struct{})
+	var ready, wg sync.WaitGroup
+	ready.Add(concurrency)
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func(i int) {
+			defer wg.Done()
+			ready.Done()
+			<-start // all goroutines fire together, maximizing overlap on the race window
+			resp := httptest.NewRecorder()
+			server.E().ServeHTTP(resp, requests[i])
+			codes[i] = resp.Code
+		}(i)
+	}
+	ready.Wait()
+	close(start)
+	wg.Wait()
+
+	created, conflicted, other := 0, 0, 0
+	for _, code := range codes {
+		switch code {
+		case http.StatusCreated:
+			created++
+		case http.StatusConflict:
+			conflicted++
+		default:
+			other++
+		}
+	}
+	suite.Equal(0, other, "expected no unexpected status codes, got codes: %v", codes)
+	suite.Equal(1, created, "expected exactly one request to create the export, got codes: %v", codes)
+	suite.Equal(concurrency-1, conflicted, "expected all other requests to conflict, got codes: %v", codes)
+
+	var count int64
+	suite.Require().NoError(suite.DB.Table("exports").Where("by_component_id = ?", controlBCUUID).Count(&count).Error)
+	suite.Equal(int64(1), count, "expected exactly one export row for the by-component")
+}
+
 // setupSSPWithExports extends setupSSPWithByComponents by also creating an empty Export
 // on both the control-level and statement-level by-components, since Provided and
 // Responsibility entries nest under an existing Export.
@@ -1744,15 +1801,28 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestSSPExportRoundTrip() {
 	}
 	suite.Require().NotNil(reexportedReq)
 	suite.Require().NotNil(reexportedReq.ByComponents)
+	suite.Require().NotEmpty(*reexportedReq.ByComponents)
 	reexportedControlBC := (*reexportedReq.ByComponents)[0]
 
+	suite.Require().NotNil(reexportedControlBC.Satisfied)
+	suite.Require().NotNil(reexportedControlBC.Inherited)
+	suite.Require().NotNil(reexportedControlBC.Export)
+	suite.Require().NotNil(reexportedControlBC.Export.Provided)
+	suite.Require().NotNil(reexportedControlBC.Export.Responsibilities)
 	suite.Equal(*exportedControlBC.Satisfied, *reexportedControlBC.Satisfied)
 	suite.Equal(*exportedControlBC.Inherited, *reexportedControlBC.Inherited)
 	suite.Equal(*exportedControlBC.Export.Provided, *reexportedControlBC.Export.Provided)
 	suite.Equal(*exportedControlBC.Export.Responsibilities, *reexportedControlBC.Export.Responsibilities)
 
 	suite.Require().NotNil(reexportedReq.Statements)
-	reexportedStmtBC := (*(*reexportedReq.Statements)[0].ByComponents)[0]
+	suite.Require().NotEmpty(*reexportedReq.Statements)
+	reexportedStmt := (*reexportedReq.Statements)[0]
+	suite.Require().NotNil(reexportedStmt.ByComponents)
+	suite.Require().NotEmpty(*reexportedStmt.ByComponents)
+	reexportedStmtBC := (*reexportedStmt.ByComponents)[0]
+	suite.Require().NotNil(reexportedStmtBC.Export)
+	suite.Require().NotNil(reexportedStmtBC.Export.Provided)
+	suite.Require().NotNil(reexportedStmtBC.Export.Responsibilities)
 	suite.Equal(*exportedStmtBC.Export.Provided, *reexportedStmtBC.Export.Provided)
 	suite.Equal(*exportedStmtBC.Export.Responsibilities, *reexportedStmtBC.Export.Responsibilities)
 }

--- a/internal/service/relational/system_security_plan.go
+++ b/internal/service/relational/system_security_plan.go
@@ -1392,7 +1392,7 @@ func (bc *ByComponent) MarshalOscal() *oscalTypes_1_1_3.ByComponent {
 	}
 
 	if len(bc.Satisfied) > 0 {
-		satisfied := make([]oscalTypes_1_1_3.SatisfiedControlImplementationResponsibility, len(bc.Inherited))
+		satisfied := make([]oscalTypes_1_1_3.SatisfiedControlImplementationResponsibility, len(bc.Satisfied))
 		for i, rr := range bc.Satisfied {
 			satisfied[i] = *rr.MarshalOscal()
 		}

--- a/internal/service/relational/system_security_plan_test.go
+++ b/internal/service/relational/system_security_plan_test.go
@@ -9,6 +9,7 @@ import (
 	oscalTypes_1_1_3 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/datatypes"
 )
 
@@ -248,6 +249,69 @@ func TestByComponent_OscalMarshalling(t *testing.T) {
 	outputJson, err := json.Marshal(output)
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(inputJson), string(outputJson))
+}
+
+func TestByComponent_MarshalOscal_SatisfiedInheritedCountMismatch(t *testing.T) {
+	makeInherited := func(n int) []InheritedControlImplementation {
+		out := make([]InheritedControlImplementation, n)
+		for i := range out {
+			id := uuid.New()
+			out[i] = InheritedControlImplementation{
+				UUIDModel:   UUIDModel{ID: &id},
+				Description: "inherited",
+			}
+		}
+		return out
+	}
+	makeSatisfied := func(n int) []SatisfiedControlImplementationResponsibility {
+		out := make([]SatisfiedControlImplementationResponsibility, n)
+		for i := range out {
+			id := uuid.New()
+			out[i] = SatisfiedControlImplementationResponsibility{
+				UUIDModel:   UUIDModel{ID: &id},
+				Description: "satisfied",
+			}
+		}
+		return out
+	}
+
+	bcID := uuid.New()
+	componentID := uuid.New()
+
+	t.Run("more satisfied than inherited", func(t *testing.T) {
+		bc := &ByComponent{
+			UUIDModel:     UUIDModel{ID: &bcID},
+			ComponentUUID: componentID,
+			Inherited:     makeInherited(1),
+			Satisfied:     makeSatisfied(3),
+		}
+
+		var output *oscalTypes_1_1_3.ByComponent
+		assert.NotPanics(t, func() {
+			output = bc.MarshalOscal()
+		})
+		require.NotNil(t, output.Satisfied)
+		require.Len(t, *output.Satisfied, 3)
+		for i, s := range *output.Satisfied {
+			assert.Equal(t, bc.Satisfied[i].ID.String(), s.UUID)
+			assert.Equal(t, "satisfied", s.Description)
+		}
+	})
+
+	t.Run("fewer satisfied than inherited", func(t *testing.T) {
+		bc := &ByComponent{
+			UUIDModel:     UUIDModel{ID: &bcID},
+			ComponentUUID: componentID,
+			Inherited:     makeInherited(3),
+			Satisfied:     makeSatisfied(1),
+		}
+
+		output := bc.MarshalOscal()
+		assert.NotNil(t, output.Satisfied)
+		assert.Len(t, *output.Satisfied, 1)
+		assert.Equal(t, bc.Satisfied[0].ID.String(), (*output.Satisfied)[0].UUID)
+		assert.Equal(t, "satisfied", (*output.Satisfied)[0].Description)
+	})
 }
 
 func TestImplementedRequirement_OscalMarshalling(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes `ByComponent.MarshalOscal` allocating the `Satisfied` OSCAL slice with `len(bc.Inherited)` instead of `len(bc.Satisfied)`, which panicked or emitted zero-value junk whenever the two counts differed.
- Adds CRUD routes for the `Export` sub-resource (and its nested `Provided`/`Responsibility` entries) on by-components, at both control-level (implemented-requirement) and statement-level, guarded by the existing `ssp:read/create/update/delete` authz actions — the foundation for the Cross-SSP Control Export/Import (Leveraged Authorization) design, Phase 0.
- No DB schema change — `Export`/`ProvidedControlImplementation`/`ControlImplementationResponsibility` were already migrated models; only handler routes were missing.

## Design notes
- Provided/Responsibility entries get dedicated per-item routes (`POST`/`PUT`/`DELETE .../export/provided/:providedId`, `.../export/responsibilities/:responsibilityId`) rather than being managed via a whole-Export replace, so a client can mutate a single entry without resending the full array and without relying on GORM's default `Save()` to correctly delete array entries dropped from a full-object PUT.
- `PUT .../export` updates only scalar fields (description/remarks/props/links) and now returns 400 if the payload carries non-empty `Provided`/`Responsibilities` arrays, since those must go through their own routes.
- `DELETE .../export` cascades to its `Provided`/`Responsibility` children inside a transaction (no DB-level cascade exists, and none was added per the "no schema change" constraint).

## Known limitations (flagged, not fixed — see PR discussion for rationale)
- Deleting a by-component via the pre-existing `DeleteImplementedRequirementStatementByComponent`/`DeleteImplementedRequirement` routes does not cascade to the new Export subtree, orphaning it. This mirrors an existing gap in those routes (they already don't cascade to `Inherited`/`Satisfied`/`ResponsibleRoles` either) — fixing it only for Export would be an inconsistent partial fix; recommend a follow-up ticket for a holistic by-component-lifecycle cascade.
- `createByComponentExport` has a TOCTOU race under concurrent requests (two POSTs to the same by-component could both create an Export). The correct fix is a unique DB constraint, which this ticket's "no schema change" constraint forbids.

## Test plan
- [x] Unit test: `ByComponent.MarshalOscal` with N `Inherited`, M `Satisfied`, N≠M (both directions) — confirmed it panics without the fix and passes with it.
- [x] Integration: create/read/update/delete an Export on a control-level and a statement-level by-component.
- [x] Integration: create/update/delete a Provided entry and a Responsibility entry on both levels.
- [x] Integration: author Export/Provided/Responsibility/Satisfied/Inherited data, fetch the full SSP (`GET .../full`, same `MarshalOscal()` path as `ccf oscal export`), then round-trip it through `UnmarshalOscal`→`MarshalOscal` and assert no data loss.
- [x] `go build ./...`, `go vet`, `golangci-lint run`, `go test ./... --tags integration` all pass repo-wide.
- [x] `go tool swag init`/`fmt` regenerated, `go mod tidy` produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API support for managing by-component exports in System Security Plans, including both requirement-level and statement-level endpoints.
  * Added nested management for exported provided items and responsibility entries.

* **Bug Fixes**
  * Fixed export rendering so provided and responsibility data are preserved correctly.
  * Improved reliability when export item counts differ, preventing malformed output and crashes.

* **Tests**
  * Added end-to-end coverage for create, update, delete, duplicate, and missing-resource scenarios across export resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->