### PR TITLE
BCH-1356: Cascade-delete by-component subtree on requirement/by-component delete

### DIFF
--- a/internal/api/handler/oscal/system_security_plans.go
+++ b/internal/api/handler/oscal/system_security_plans.go
@@ -4928,28 +4928,37 @@ func (h *SystemSecurityPlanHandler) deleteByComponentExport(ctx echo.Context, bc
 	}
 
 	if err := h.db.Transaction(func(tx *gorm.DB) error {
-		for _, provided := range existing.Provided {
-			if err := deleteResponsibleRoles(tx, provided.ResponsibleRoles); err != nil {
-				return err
-			}
-		}
-		for _, resp := range existing.Responsibilities {
-			if err := deleteResponsibleRoles(tx, resp.ResponsibleRoles); err != nil {
-				return err
-			}
-		}
-		if err := tx.Where("export_id = ?", existing.ID).Delete(&relational.ProvidedControlImplementation{}).Error; err != nil {
-			return err
-		}
-		if err := tx.Where("export_id = ?", existing.ID).Delete(&relational.ControlImplementationResponsibility{}).Error; err != nil {
-			return err
-		}
-		return tx.Delete(&existing).Error
+		return deleteExportCascade(tx, &existing)
 	}); err != nil {
 		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
 	}
 
 	return ctx.NoContent(http.StatusNoContent)
+}
+
+// deleteExportCascade deletes an Export's nested Provided and Responsibilities
+// entries (and their ResponsibleRoles/parties), then the Export itself. Shared
+// by deleteByComponentExport and deleteByComponentCascade so the two paths
+// can't drift apart. export.Provided and export.Responsibilities (with their
+// ResponsibleRoles.Parties) must already be preloaded by the caller.
+func deleteExportCascade(tx *gorm.DB, export *relational.Export) error {
+	for _, provided := range export.Provided {
+		if err := deleteResponsibleRoles(tx, provided.ResponsibleRoles); err != nil {
+			return err
+		}
+	}
+	for _, resp := range export.Responsibilities {
+		if err := deleteResponsibleRoles(tx, resp.ResponsibleRoles); err != nil {
+			return err
+		}
+	}
+	if err := tx.Where("export_id = ?", export.ID).Delete(&relational.ProvidedControlImplementation{}).Error; err != nil {
+		return err
+	}
+	if err := tx.Where("export_id = ?", export.ID).Delete(&relational.ControlImplementationResponsibility{}).Error; err != nil {
+		return err
+	}
+	return tx.Delete(export).Error
 }
 
 // deleteResponsibleRoles removes the given ResponsibleRoles along with their
@@ -5010,23 +5019,7 @@ func deleteByComponentCascade(tx *gorm.DB, byComponentID uuid.UUID) error {
 	}
 
 	if bc.Export != nil {
-		for _, provided := range bc.Export.Provided {
-			if err := deleteResponsibleRoles(tx, provided.ResponsibleRoles); err != nil {
-				return err
-			}
-		}
-		for _, resp := range bc.Export.Responsibilities {
-			if err := deleteResponsibleRoles(tx, resp.ResponsibleRoles); err != nil {
-				return err
-			}
-		}
-		if err := tx.Where("export_id = ?", bc.Export.ID).Delete(&relational.ProvidedControlImplementation{}).Error; err != nil {
-			return err
-		}
-		if err := tx.Where("export_id = ?", bc.Export.ID).Delete(&relational.ControlImplementationResponsibility{}).Error; err != nil {
-			return err
-		}
-		if err := tx.Delete(bc.Export).Error; err != nil {
+		if err := deleteExportCascade(tx, bc.Export); err != nil {
 			return err
 		}
 	}

--- a/internal/api/handler/oscal/system_security_plans.go
+++ b/internal/api/handler/oscal/system_security_plans.go
@@ -3853,14 +3853,47 @@ func (h *SystemSecurityPlanHandler) DeleteImplementedRequirement(ctx echo.Contex
 		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
 	}
 
-	result := h.db.Where("id = ? AND control_implementation_id = ?", reqID, ssp.ControlImplementation.ID).Delete(&relational.ImplementedRequirement{})
-	if result.Error != nil {
-		h.sugar.Errorf("Failed to delete implemented requirement: %v", result.Error)
-		return ctx.JSON(http.StatusInternalServerError, api.NewError(result.Error))
+	var req relational.ImplementedRequirement
+	if err := h.db.
+		Preload("ResponsibleRoles.Parties").
+		Preload("ByComponents").
+		Preload("Statements.ResponsibleRoles.Parties").
+		Preload("Statements.ByComponents").
+		Where("id = ? AND control_implementation_id = ?", reqID, ssp.ControlImplementation.ID).
+		First(&req).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("implemented requirement not found")))
+		}
+		h.sugar.Errorf("Failed to find implemented requirement: %v", err)
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
 	}
 
-	if result.RowsAffected == 0 {
-		return ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("implemented requirement not found")))
+	if err := h.db.Transaction(func(tx *gorm.DB) error {
+		for _, bc := range req.ByComponents {
+			if err := deleteByComponentCascade(tx, *bc.ID); err != nil {
+				return err
+			}
+		}
+		for _, stmt := range req.Statements {
+			for _, bc := range stmt.ByComponents {
+				if err := deleteByComponentCascade(tx, *bc.ID); err != nil {
+					return err
+				}
+			}
+			if err := deleteResponsibleRoles(tx, stmt.ResponsibleRoles); err != nil {
+				return err
+			}
+		}
+		if err := deleteResponsibleRoles(tx, req.ResponsibleRoles); err != nil {
+			return err
+		}
+		if err := tx.Where("implemented_requirement_id = ?", req.ID).Delete(&relational.Statement{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&req).Error
+	}); err != nil {
+		h.sugar.Errorf("Failed to delete implemented requirement: %v", err)
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
 	}
 
 	return ctx.NoContent(http.StatusNoContent)
@@ -4522,10 +4555,11 @@ func (h *SystemSecurityPlanHandler) DeleteImplementedRequirementStatementByCompo
 		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
 	}
 
-	if err := h.db.Delete(&existing).Error; err != nil {
+	if err := h.db.Transaction(func(tx *gorm.DB) error {
+		return deleteByComponentCascade(tx, *existing.ID)
+	}); err != nil {
 		h.sugar.Errorf("Failed to delete by-component: %v", err)
 		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
-
 	}
 	return ctx.NoContent(http.StatusNoContent)
 }
@@ -4878,11 +4912,15 @@ func (h *SystemSecurityPlanHandler) updateByComponentExport(ctx echo.Context, bc
 }
 
 // deleteByComponentExport deletes an existing Export and its nested Provided and
-// Responsibilities entries. Children are deleted explicitly rather than relying on a
-// DB-level cascade, since this ticket makes no schema change.
+// Responsibilities entries, including their ResponsibleRoles and responsible_role_parties
+// join rows. Children are deleted explicitly rather than relying on a DB-level cascade,
+// since this ticket makes no schema change.
 func (h *SystemSecurityPlanHandler) deleteByComponentExport(ctx echo.Context, bc *relational.ByComponent) error {
 	var existing relational.Export
-	if err := h.db.Where("by_component_id = ?", bc.ID).First(&existing).Error; err != nil {
+	if err := h.db.
+		Preload("Provided.ResponsibleRoles.Parties").
+		Preload("Responsibilities.ResponsibleRoles.Parties").
+		Where("by_component_id = ?", bc.ID).First(&existing).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return ctx.JSON(http.StatusNotFound, api.NewError(fmt.Errorf("export not found")))
 		}
@@ -4890,6 +4928,16 @@ func (h *SystemSecurityPlanHandler) deleteByComponentExport(ctx echo.Context, bc
 	}
 
 	if err := h.db.Transaction(func(tx *gorm.DB) error {
+		for _, provided := range existing.Provided {
+			if err := deleteResponsibleRoles(tx, provided.ResponsibleRoles); err != nil {
+				return err
+			}
+		}
+		for _, resp := range existing.Responsibilities {
+			if err := deleteResponsibleRoles(tx, resp.ResponsibleRoles); err != nil {
+				return err
+			}
+		}
 		if err := tx.Where("export_id = ?", existing.ID).Delete(&relational.ProvidedControlImplementation{}).Error; err != nil {
 			return err
 		}
@@ -4902,6 +4950,88 @@ func (h *SystemSecurityPlanHandler) deleteByComponentExport(ctx echo.Context, bc
 	}
 
 	return ctx.NoContent(http.StatusNoContent)
+}
+
+// deleteResponsibleRoles removes the given ResponsibleRoles along with their
+// many2many Party join rows. The join rows are cleared explicitly first since
+// deleting a ResponsibleRole directly would leave its responsible_role_parties
+// rows behind (Party records themselves are shared and must not be deleted).
+func deleteResponsibleRoles(tx *gorm.DB, roles []relational.ResponsibleRole) error {
+	for i := range roles {
+		role := &roles[i]
+		if err := tx.Model(role).Association("Parties").Clear(); err != nil {
+			return err
+		}
+		if err := tx.Delete(role).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteByComponentCascade deletes a ByComponent and every record that hangs off
+// it: its own ResponsibleRoles, its Inherited and Satisfied entries (each with
+// their own ResponsibleRoles), and its Export with nested Provided and
+// Responsibilities entries (each with their own ResponsibleRoles). None of this
+// cascades at the DB level, so it is deleted explicitly, leaves-first, inside
+// the caller's transaction.
+func deleteByComponentCascade(tx *gorm.DB, byComponentID uuid.UUID) error {
+	var bc relational.ByComponent
+	if err := tx.
+		Preload("ResponsibleRoles.Parties").
+		Preload("Inherited.ResponsibleRoles.Parties").
+		Preload("Satisfied.ResponsibleRoles.Parties").
+		Preload("Export.Provided.ResponsibleRoles.Parties").
+		Preload("Export.Responsibilities.ResponsibleRoles.Parties").
+		First(&bc, "id = ?", byComponentID).Error; err != nil {
+		return err
+	}
+
+	if err := deleteResponsibleRoles(tx, bc.ResponsibleRoles); err != nil {
+		return err
+	}
+
+	for _, inherited := range bc.Inherited {
+		if err := deleteResponsibleRoles(tx, inherited.ResponsibleRoles); err != nil {
+			return err
+		}
+	}
+	if err := tx.Where("by_component_id = ?", bc.ID).Delete(&relational.InheritedControlImplementation{}).Error; err != nil {
+		return err
+	}
+
+	for _, satisfied := range bc.Satisfied {
+		if err := deleteResponsibleRoles(tx, satisfied.ResponsibleRoles); err != nil {
+			return err
+		}
+	}
+	if err := tx.Where("by_component_id = ?", bc.ID).Delete(&relational.SatisfiedControlImplementationResponsibility{}).Error; err != nil {
+		return err
+	}
+
+	if bc.Export != nil {
+		for _, provided := range bc.Export.Provided {
+			if err := deleteResponsibleRoles(tx, provided.ResponsibleRoles); err != nil {
+				return err
+			}
+		}
+		for _, resp := range bc.Export.Responsibilities {
+			if err := deleteResponsibleRoles(tx, resp.ResponsibleRoles); err != nil {
+				return err
+			}
+		}
+		if err := tx.Where("export_id = ?", bc.Export.ID).Delete(&relational.ProvidedControlImplementation{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("export_id = ?", bc.Export.ID).Delete(&relational.ControlImplementationResponsibility{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Delete(bc.Export).Error; err != nil {
+			return err
+		}
+	}
+
+	return tx.Delete(&bc).Error
 }
 
 // GetImplementedRequirementByComponentExport godoc

--- a/internal/api/handler/oscal/system_security_plans_test.go
+++ b/internal/api/handler/oscal/system_security_plans_test.go
@@ -978,6 +978,272 @@ func (suite *SystemSecurityPlanApiIntegrationSuite) TestDeleteImplementedRequire
 	suite.Equal(http.StatusNotFound, resp.Code)
 }
 
+// byComponentSubtreeIDs captures the UUIDs of every nested entity created by
+// buildFullByComponentFixture, so cascade-delete tests can look each one up in
+// the DB directly (OSCAL ResponsibleRole values have no UUID of their own).
+type byComponentSubtreeIDs struct {
+	ByComponent    string
+	Inherited      string
+	Satisfied      string
+	Provided       string
+	Responsibility string
+}
+
+// buildFullByComponentFixture builds a ByComponent payload populated at every
+// nested level (ResponsibleRoles, Inherited, Satisfied, Export/Provided/
+// Responsibilities), each carrying its own ResponsibleRole+party, so a cascade
+// delete test can confirm the whole subtree is cleaned up and not just the
+// ByComponent row itself.
+func buildFullByComponentFixture(componentUuid, partyUuid string) (oscalTypes_1_1_3.ByComponent, byComponentSubtreeIDs) {
+	ids := byComponentSubtreeIDs{
+		ByComponent:    uuid.New().String(),
+		Inherited:      uuid.New().String(),
+		Satisfied:      uuid.New().String(),
+		Provided:       uuid.New().String(),
+		Responsibility: uuid.New().String(),
+	}
+
+	role := func(roleID string) oscalTypes_1_1_3.ResponsibleRole {
+		return oscalTypes_1_1_3.ResponsibleRole{
+			RoleId:     roleID,
+			PartyUuids: &[]string{partyUuid},
+		}
+	}
+
+	bc := oscalTypes_1_1_3.ByComponent{
+		UUID:             ids.ByComponent,
+		ComponentUuid:    componentUuid,
+		Description:      "Full subtree by-component",
+		ResponsibleRoles: &[]oscalTypes_1_1_3.ResponsibleRole{role("bc-role")},
+		Inherited: &[]oscalTypes_1_1_3.InheritedControlImplementation{
+			{
+				UUID:             ids.Inherited,
+				Description:      "Inherited item",
+				ResponsibleRoles: &[]oscalTypes_1_1_3.ResponsibleRole{role("inherited-role")},
+			},
+		},
+		Satisfied: &[]oscalTypes_1_1_3.SatisfiedControlImplementationResponsibility{
+			{
+				UUID:             ids.Satisfied,
+				Description:      "Satisfied item",
+				ResponsibleRoles: &[]oscalTypes_1_1_3.ResponsibleRole{role("satisfied-role")},
+			},
+		},
+		Export: &oscalTypes_1_1_3.Export{
+			Description: "Export subtree",
+			Provided: &[]oscalTypes_1_1_3.ProvidedControlImplementation{
+				{
+					UUID:             ids.Provided,
+					Description:      "Provided item",
+					ResponsibleRoles: &[]oscalTypes_1_1_3.ResponsibleRole{role("provided-role")},
+				},
+			},
+			Responsibilities: &[]oscalTypes_1_1_3.ControlImplementationResponsibility{
+				{
+					UUID:             ids.Responsibility,
+					Description:      "Responsibility item",
+					ProvidedUuid:     ids.Provided,
+					ResponsibleRoles: &[]oscalTypes_1_1_3.ResponsibleRole{role("responsibility-role")},
+				},
+			},
+		},
+	}
+
+	return bc, ids
+}
+
+// byComponentSubtreeRowCounts reports the row count for every table in a
+// by-component's cascade subtree, so a test can assert everything landed on
+// create (non-zero) and everything vanished on delete (all zero).
+func (suite *SystemSecurityPlanApiIntegrationSuite) byComponentSubtreeRowCounts(ids byComponentSubtreeIDs) map[string]int64 {
+	var byComponent, inherited, satisfied, export, provided, responsibility, responsibleRoles, responsibleRoleParties int64
+
+	suite.DB.Model(&relational.ByComponent{}).Where("id = ?", ids.ByComponent).Count(&byComponent)
+	suite.DB.Model(&relational.InheritedControlImplementation{}).Where("by_component_id = ?", ids.ByComponent).Count(&inherited)
+	suite.DB.Model(&relational.SatisfiedControlImplementationResponsibility{}).Where("by_component_id = ?", ids.ByComponent).Count(&satisfied)
+	suite.DB.Model(&relational.Export{}).Where("by_component_id = ?", ids.ByComponent).Count(&export)
+	suite.DB.Model(&relational.ProvidedControlImplementation{}).Where("id = ?", ids.Provided).Count(&provided)
+	suite.DB.Model(&relational.ControlImplementationResponsibility{}).Where("id = ?", ids.Responsibility).Count(&responsibility)
+
+	parentIDs := []string{ids.ByComponent, ids.Inherited, ids.Satisfied, ids.Provided, ids.Responsibility}
+	suite.DB.Model(&relational.ResponsibleRole{}).Where("parent_id IN ?", parentIDs).Count(&responsibleRoles)
+	suite.DB.Table("responsible_role_parties").
+		Joins("JOIN responsible_roles ON responsible_roles.id = responsible_role_parties.responsible_role_id").
+		Where("responsible_roles.parent_id IN ?", parentIDs).
+		Count(&responsibleRoleParties)
+
+	return map[string]int64{
+		"by_component":             byComponent,
+		"inherited":                inherited,
+		"satisfied":                satisfied,
+		"export":                   export,
+		"provided":                 provided,
+		"responsibility":           responsibility,
+		"responsible_roles":        responsibleRoles,
+		"responsible_role_parties": responsibleRoleParties,
+	}
+}
+
+// TestDeleteImplementedRequirementStatementByComponent_CascadesOrphanedRecords
+// captures BCH-1356: deleting a statement-level by-component only removed the
+// by-component row itself, leaving its Inherited, Satisfied, Export (with
+// nested Provided/Responsibilities), and every level's ResponsibleRoles (plus
+// the responsible_role_parties join rows) orphaned in the database.
+func (suite *SystemSecurityPlanApiIntegrationSuite) TestDeleteImplementedRequirementStatementByComponent_CascadesOrphanedRecords() {
+	logConf := zap.NewDevelopmentConfig()
+	logConf.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
+	logger, _ := logConf.Build()
+
+	err := suite.Migrator.Refresh()
+	suite.Require().NoError(err)
+
+	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
+	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
+	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil, nil)
+
+	ssp := suite.createBasicSSP()
+	componentUuid := ssp.SystemImplementation.Components[0].UUID
+	partyUuid := (*ssp.Metadata.Parties)[0].UUID
+	ssp.ControlImplementation.ImplementedRequirements[0].Statements = nil
+
+	req := suite.createRequest("POST", "/api/oscal/system-security-plans", ssp)
+	resp := httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusCreated, resp.Code)
+
+	fullBC, ids := buildFullByComponentFixture(componentUuid, partyUuid)
+
+	implementedReq := oscalTypes_1_1_3.ImplementedRequirement{
+		UUID:      uuid.New().String(),
+		ControlId: "ac-1",
+		Statements: &[]oscalTypes_1_1_3.Statement{
+			{
+				UUID:         uuid.New().String(),
+				StatementId:  "ac-1_stmt.a",
+				ByComponents: &[]oscalTypes_1_1_3.ByComponent{fullBC},
+			},
+		},
+	}
+
+	req = suite.createRequest("POST", fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements", ssp.UUID), implementedReq)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusCreated, resp.Code)
+
+	var createResponse handler.GenericDataResponse[oscalTypes_1_1_3.ImplementedRequirement]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &createResponse))
+	requirement := createResponse.Data
+	suite.Require().NotNil(requirement.Statements)
+	suite.Require().NotEmpty(*requirement.Statements)
+	statement := (*requirement.Statements)[0]
+
+	// Sanity check: the full subtree actually landed in the DB before we try to delete it.
+	before := suite.byComponentSubtreeRowCounts(ids)
+	for table, count := range before {
+		suite.Require().Greaterf(count, int64(0), "expected fixture to create at least one %s row before delete", table)
+	}
+
+	req = suite.createRequest("DELETE", fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s/statements/%s/by-components/%s",
+		ssp.UUID, requirement.UUID, statement.UUID, ids.ByComponent), nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusNoContent, resp.Code)
+
+	after := suite.byComponentSubtreeRowCounts(ids)
+	for table, count := range after {
+		suite.Equalf(int64(0), count, "expected %s rows to be cascade-deleted with the by-component, found %d", table, count)
+	}
+}
+
+// TestDeleteImplementedRequirement_CascadesOrphanedRecords captures BCH-1356 for
+// the requirement-level delete path: it must cascade to the requirement's own
+// ResponsibleRoles(+parties), its Statements, and every by-component subtree
+// hanging off either the requirement directly (control-level) or one of its
+// statements (statement-level) — including each subtree's Inherited, Satisfied,
+// and Export/Provided/Responsibilities records.
+func (suite *SystemSecurityPlanApiIntegrationSuite) TestDeleteImplementedRequirement_CascadesOrphanedRecords() {
+	logConf := zap.NewDevelopmentConfig()
+	logConf.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
+	logger, _ := logConf.Build()
+
+	err := suite.Migrator.Refresh()
+	suite.Require().NoError(err)
+
+	metrics := api.NewMetricsHandler(context.Background(), logger.Sugar())
+	server := api.NewServer(context.Background(), logger.Sugar(), suite.Config, metrics)
+	evidenceSvc := evidencesvc.NewEvidenceService(suite.DB, logger.Sugar(), suite.Config, nil)
+	RegisterHandlers(server, logger.Sugar(), suite.DB, suite.Config, evidenceSvc, nil, nil)
+
+	ssp := suite.createBasicSSP()
+	componentUuid := ssp.SystemImplementation.Components[0].UUID
+	partyUuid := (*ssp.Metadata.Parties)[0].UUID
+	ssp.ControlImplementation.ImplementedRequirements[0].Statements = nil
+
+	req := suite.createRequest("POST", "/api/oscal/system-security-plans", ssp)
+	resp := httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusCreated, resp.Code)
+
+	controlBC, controlIDs := buildFullByComponentFixture(componentUuid, partyUuid)
+	stmtBC, stmtIDs := buildFullByComponentFixture(componentUuid, partyUuid)
+	stmtUUID := uuid.New().String()
+
+	implementedReq := oscalTypes_1_1_3.ImplementedRequirement{
+		UUID:             uuid.New().String(),
+		ControlId:        "ac-1",
+		ByComponents:     &[]oscalTypes_1_1_3.ByComponent{controlBC},
+		ResponsibleRoles: &[]oscalTypes_1_1_3.ResponsibleRole{{RoleId: "ir-role", PartyUuids: &[]string{partyUuid}}},
+		Statements: &[]oscalTypes_1_1_3.Statement{
+			{
+				UUID:         stmtUUID,
+				StatementId:  "ac-1_stmt.a",
+				ByComponents: &[]oscalTypes_1_1_3.ByComponent{stmtBC},
+			},
+		},
+	}
+
+	req = suite.createRequest("POST", fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements", ssp.UUID), implementedReq)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusCreated, resp.Code)
+
+	var createResponse handler.GenericDataResponse[oscalTypes_1_1_3.ImplementedRequirement]
+	suite.Require().NoError(json.Unmarshal(resp.Body.Bytes(), &createResponse))
+	requirement := createResponse.Data
+
+	// Sanity check: everything actually landed before we try to delete it.
+	for _, ids := range []byComponentSubtreeIDs{controlIDs, stmtIDs} {
+		counts := suite.byComponentSubtreeRowCounts(ids)
+		for table, count := range counts {
+			suite.Require().Greaterf(count, int64(0), "expected fixture to create at least one %s row before delete", table)
+		}
+	}
+	var irRoleCountBefore, stmtCountBefore int64
+	suite.DB.Model(&relational.ResponsibleRole{}).Where("parent_id = ?", requirement.UUID).Count(&irRoleCountBefore)
+	suite.DB.Model(&relational.Statement{}).Where("id = ?", stmtUUID).Count(&stmtCountBefore)
+	suite.Require().Greater(irRoleCountBefore, int64(0))
+	suite.Require().Greater(stmtCountBefore, int64(0))
+
+	req = suite.createRequest("DELETE", fmt.Sprintf("/api/oscal/system-security-plans/%s/control-implementation/implemented-requirements/%s",
+		ssp.UUID, requirement.UUID), nil)
+	resp = httptest.NewRecorder()
+	server.E().ServeHTTP(resp, req)
+	suite.Require().Equal(http.StatusNoContent, resp.Code)
+
+	for _, ids := range []byComponentSubtreeIDs{controlIDs, stmtIDs} {
+		counts := suite.byComponentSubtreeRowCounts(ids)
+		for table, count := range counts {
+			suite.Equalf(int64(0), count, "expected %s rows to be cascade-deleted with the requirement, found %d", table, count)
+		}
+	}
+	var irRoleCountAfter, stmtCountAfter int64
+	suite.DB.Model(&relational.ResponsibleRole{}).Where("parent_id = ?", requirement.UUID).Count(&irRoleCountAfter)
+	suite.DB.Model(&relational.Statement{}).Where("id = ?", stmtUUID).Count(&stmtCountAfter)
+	suite.Equal(int64(0), irRoleCountAfter)
+	suite.Equal(int64(0), stmtCountAfter)
+}
+
 // Test creating a by-component within a statement within an implemented requirement
 func (suite *SystemSecurityPlanApiIntegrationSuite) TestCreateImplementedRequirementStatementByComponent() {
 	logConf := zap.NewDevelopmentConfig()


### PR DESCRIPTION
## Summary
- `DeleteImplementedRequirement` and `DeleteImplementedRequirementStatementByComponent` only deleted the top-level row (no DB-level cascade exists on these tables), orphaning `Inherited`, `Satisfied`, `Export`/`Provided`/`Responsibilities`, and every level's `ResponsibleRole` + `responsible_role_parties` join rows.
- Adds two shared helpers: `deleteResponsibleRoles` (clears the many2many party join rows, then deletes the role) and `deleteByComponentCascade` (walks a by-component's full subtree leaf-first). Wired into both delete routes.
- `DeleteImplementedRequirement` also now cascades the requirement's own `ResponsibleRoles`, each statement's own `ResponsibleRoles`, and the statements themselves.
- Also applied the same fix to `deleteByComponentExport` (introduced in #444), which had the identical gap for Export's nested Provided/Responsibilities roles — this closes the "orphaned ResponsibleRoles" item deferred from that PR's review.

## Test plan
- [x] Added `TestDeleteImplementedRequirementStatementByComponent_CascadesOrphanedRecords` and `TestDeleteImplementedRequirement_CascadesOrphanedRecords`, each building a by-component with a fully populated subtree (roles+party at every level, inherited, satisfied, export/provided/responsibility) and asserting every table is empty after delete. Confirmed both fail against the pre-fix code.
- [x] Full SSP integration suite passes (44/44).
- [x] `make reviewable` (swag/lint/test-integration) clean; no swagger diff since no route shapes changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting implemented requirements and statement-level components now removes all related nested records consistently, reducing leftover/orphaned data.
  * Related roles, exports, and component sub-items are now cleaned up together during deletion.
* **Tests**
  * Added coverage for deletion scenarios to verify nested records are removed across the full hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->