### PR TITLE
BCH-1339: Responsibility-scoped filters, SSP resolution, and posture (Phase 3)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -21082,7 +21082,7 @@ const docTemplate = `{
         },
         "/oscal/system-security-plans/{id}/leveraged-controls": {
             "get": {
-                "description": "Read-only view over the downstream SSP's own inherited/satisfied entries\njoined to ssp_leverage_links + the upstream offering. Per control/statement,\nreturns which offering it was inherited from, whether satisfaction is full\nor partial (recomputed live from the current satisfied-responsibility rows,\nnot trusted from the link's stored value), and any outstanding\nresponsibilities. Writes nothing; never touches profile_controls/controls.",
+                "description": "Read-only view over the downstream SSP's own inherited/satisfied entries\njoined to ssp_leverage_links + the upstream offering. Per control/statement,\nreturns which offering it was inherited from, whether satisfaction is full\nor partial (recomputed live from the current satisfied-responsibility rows,\nnot trusted from the link's stored value), any outstanding\nresponsibilities, and live evidence-backed posture per responsibility uuid\n(satisfied/not-satisfied/unknown, via filter_responsibilities). Writes\nnothing; never touches profile_controls/controls.",
                 "produces": [
                     "application/json"
                 ],
@@ -38756,6 +38756,13 @@ const docTemplate = `{
                         "$ref": "#/definitions/oscal.upstreamResponsibility"
                     }
                 },
+                "responsibilityPosture": {
+                    "description": "ResponsibilityPosture is the live, evidence-backed posture (satisfied /\nnot-satisfied / unknown) per upstream responsibility uuid under this link's\nprovided-uuid — computed via filter_responsibilities (BCH-1339), independent of\nSatisfaction/OutstandingResponsibilities above (which reflect what was attested at\nsubscribe time, not current evidence).",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "satisfaction": {
                     "$ref": "#/definitions/relational.SSPLeverageSatisfaction"
                 },
@@ -43815,6 +43822,7 @@ const docTemplate = `{
                     }
                 },
                 "provided-uuid": {
+                    "description": "ProvidedUuid is explicitly typed uuid (unlike its historical default, aligned by\nmigrateAlignProvidedUuidColumnType for pre-existing databases): BCH-1339's\nfilter_responsibilities → ssp_leverage_links resolution arm\n(risk_evidence_worker.go) joins this column directly against\nssp_leverage_links.provided_uuid, which is uuid.",
                     "type": "string"
                 },
                 "remarks": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -21076,7 +21076,7 @@
         },
         "/oscal/system-security-plans/{id}/leveraged-controls": {
             "get": {
-                "description": "Read-only view over the downstream SSP's own inherited/satisfied entries\njoined to ssp_leverage_links + the upstream offering. Per control/statement,\nreturns which offering it was inherited from, whether satisfaction is full\nor partial (recomputed live from the current satisfied-responsibility rows,\nnot trusted from the link's stored value), and any outstanding\nresponsibilities. Writes nothing; never touches profile_controls/controls.",
+                "description": "Read-only view over the downstream SSP's own inherited/satisfied entries\njoined to ssp_leverage_links + the upstream offering. Per control/statement,\nreturns which offering it was inherited from, whether satisfaction is full\nor partial (recomputed live from the current satisfied-responsibility rows,\nnot trusted from the link's stored value), any outstanding\nresponsibilities, and live evidence-backed posture per responsibility uuid\n(satisfied/not-satisfied/unknown, via filter_responsibilities). Writes\nnothing; never touches profile_controls/controls.",
                 "produces": [
                     "application/json"
                 ],
@@ -38750,6 +38750,13 @@
                         "$ref": "#/definitions/oscal.upstreamResponsibility"
                     }
                 },
+                "responsibilityPosture": {
+                    "description": "ResponsibilityPosture is the live, evidence-backed posture (satisfied /\nnot-satisfied / unknown) per upstream responsibility uuid under this link's\nprovided-uuid — computed via filter_responsibilities (BCH-1339), independent of\nSatisfaction/OutstandingResponsibilities above (which reflect what was attested at\nsubscribe time, not current evidence).",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "satisfaction": {
                     "$ref": "#/definitions/relational.SSPLeverageSatisfaction"
                 },
@@ -43809,6 +43816,7 @@
                     }
                 },
                 "provided-uuid": {
+                    "description": "ProvidedUuid is explicitly typed uuid (unlike its historical default, aligned by\nmigrateAlignProvidedUuidColumnType for pre-existing databases): BCH-1339's\nfilter_responsibilities → ssp_leverage_links resolution arm\n(risk_evidence_worker.go) joins this column directly against\nssp_leverage_links.provided_uuid, which is uuid.",
                     "type": "string"
                 },
                 "remarks": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4341,6 +4341,16 @@ definitions:
         items:
           $ref: '#/definitions/oscal.upstreamResponsibility'
         type: array
+      responsibilityPosture:
+        additionalProperties:
+          type: string
+        description: |-
+          ResponsibilityPosture is the live, evidence-backed posture (satisfied /
+          not-satisfied / unknown) per upstream responsibility uuid under this link's
+          provided-uuid — computed via filter_responsibilities (BCH-1339), independent of
+          Satisfaction/OutstandingResponsibilities above (which reflect what was attested at
+          subscribe time, not current evidence).
+        type: object
       satisfaction:
         $ref: '#/definitions/relational.SSPLeverageSatisfaction'
       statementId:
@@ -7673,6 +7683,12 @@ definitions:
           $ref: '#/definitions/relational.Prop'
         type: array
       provided-uuid:
+        description: |-
+          ProvidedUuid is explicitly typed uuid (unlike its historical default, aligned by
+          migrateAlignProvidedUuidColumnType for pre-existing databases): BCH-1339's
+          filter_responsibilities → ssp_leverage_links resolution arm
+          (risk_evidence_worker.go) joins this column directly against
+          ssp_leverage_links.provided_uuid, which is uuid.
         type: string
       remarks:
         type: string
@@ -25221,8 +25237,10 @@ paths:
         joined to ssp_leverage_links + the upstream offering. Per control/statement,
         returns which offering it was inherited from, whether satisfaction is full
         or partial (recomputed live from the current satisfied-responsibility rows,
-        not trusted from the link's stored value), and any outstanding
-        responsibilities. Writes nothing; never touches profile_controls/controls.
+        not trusted from the link's stored value), any outstanding
+        responsibilities, and live evidence-backed posture per responsibility uuid
+        (satisfied/not-satisfied/unknown, via filter_responsibilities). Writes
+        nothing; never touches profile_controls/controls.
       parameters:
       - description: Downstream SSP ID
         in: path

--- a/internal/api/handler/oscal/profile_compliance.go
+++ b/internal/api/handler/oscal/profile_compliance.go
@@ -424,13 +424,20 @@ func (h *ProfileHandler) loadFiltersByControl(scopeControls []profileComplianceC
 }
 
 func (h *ProfileHandler) getStatusCountsForFilters(filters []labelfilter.Filter) ([]ProfileComplianceStatusCount, error) {
+	return getStatusCountsForFilters(h.db, filters)
+}
+
+// getStatusCountsForFilters is the package-level form of the method above, taking db
+// explicitly so ResponsibilityPosture can reuse the exact same evidence status-count
+// logic without needing a ProfileHandler receiver.
+func getStatusCountsForFilters(db *gorm.DB, filters []labelfilter.Filter) ([]ProfileComplianceStatusCount, error) {
 	if len(filters) == 0 {
 		return []ProfileComplianceStatusCount{}, nil
 	}
 
-	latestQuery := h.db.Session(&gorm.Session{})
+	latestQuery := db.Session(&gorm.Session{})
 	latestQuery = relational.GetLatestEvidenceStreamsQuery(latestQuery)
-	query, err := relational.GetEvidenceSearchByFilterQuery(latestQuery, h.db, filters...)
+	query, err := relational.GetEvidenceSearchByFilterQuery(latestQuery, db, filters...)
 	if err != nil {
 		return nil, err
 	}
@@ -448,6 +455,73 @@ func (h *ProfileHandler) getStatusCountsForFilters(filters []labelfilter.Filter)
 	})
 
 	return rows, nil
+}
+
+// ResponsibilityPosture computes per-responsibility compliance posture (satisfied /
+// not-satisfied / unknown) for a downstream SSP, using the same status-count/evidence
+// logic as control-keyed posture (computeProfileControlStatus), but keyed by
+// responsibility_uuid via filter_responsibilities instead of by (catalogId, controlId)
+// via filter_controls (BCH-1339). Feeds the Inherited Capability projection
+// (SSPLeverageHandler.LeveragedControls, BCH-1338 Phase 2) so a downstream can see
+// whether an inherited responsibility is actually backed by satisfying evidence, not
+// just recorded as satisfied at subscribe time. Every requested uuid is always present
+// in the returned map — defaulting to "unknown" when no filter targets it — never an
+// absent key, matching bulkResolveUpstreamResponsibilities's convention in
+// ssp_leverage.go.
+func ResponsibilityPosture(db *gorm.DB, downstreamSSPID uuid.UUID, responsibilityUUIDs []uuid.UUID) (map[uuid.UUID]string, error) {
+	posture := make(map[uuid.UUID]string, len(responsibilityUUIDs))
+	for _, id := range responsibilityUUIDs {
+		posture[id] = "unknown"
+	}
+	if len(responsibilityUUIDs) == 0 {
+		return posture, nil
+	}
+
+	var links []relational.FilterResponsibility
+	if err := db.Where("ssp_id = ? AND responsibility_uuid IN ?", downstreamSSPID, responsibilityUUIDs).
+		Find(&links).Error; err != nil {
+		return nil, err
+	}
+	if len(links) == 0 {
+		return posture, nil
+	}
+
+	filterIDs := make([]uuid.UUID, 0, len(links))
+	seenFilterIDs := make(map[uuid.UUID]bool, len(links))
+	for _, link := range links {
+		if !seenFilterIDs[link.FilterID] {
+			seenFilterIDs[link.FilterID] = true
+			filterIDs = append(filterIDs, link.FilterID)
+		}
+	}
+
+	var filters []relational.Filter
+	if err := db.Where("id IN ?", filterIDs).Find(&filters).Error; err != nil {
+		return nil, err
+	}
+	filterByID := make(map[uuid.UUID]relational.Filter, len(filters))
+	for _, f := range filters {
+		filterByID[*f.ID] = f
+	}
+
+	filtersByResponsibility := make(map[uuid.UUID][]labelfilter.Filter, len(links))
+	for _, link := range links {
+		f, ok := filterByID[link.FilterID]
+		if !ok {
+			continue
+		}
+		filtersByResponsibility[link.ResponsibilityUUID] = append(filtersByResponsibility[link.ResponsibilityUUID], f.Filter.Data())
+	}
+
+	for respID, filterList := range filtersByResponsibility {
+		statusCounts, err := getStatusCountsForFilters(db, filterList)
+		if err != nil {
+			return nil, err
+		}
+		posture[respID] = computeProfileControlStatus(statusCounts)
+	}
+
+	return posture, nil
 }
 
 func (h *ProfileHandler) loadImplementedControlsForSSP(sspID uuid.UUID) (map[string]struct{}, error) {

--- a/internal/api/handler/oscal/profile_compliance_unit_test.go
+++ b/internal/api/handler/oscal/profile_compliance_unit_test.go
@@ -1,0 +1,78 @@
+package oscal
+
+import (
+	"testing"
+
+	"github.com/compliance-framework/api/internal/service/relational"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newResponsibilityPostureTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&relational.Filter{},
+		&relational.FilterResponsibility{},
+	))
+	return db
+}
+
+// TestResponsibilityPostureEmptyInput covers the case that doesn't reach the
+// Postgres-only status-count query (GetLatestEvidenceStreamsQuery uses "DISTINCT ON",
+// unsupported by sqlite) — the satisfied/not-satisfied cases that do reach it are
+// covered by the integration suite instead, matching the existing test split for
+// getStatusCountsForFilters/ComplianceProgress.
+func TestResponsibilityPostureEmptyInput(t *testing.T) {
+	db := newResponsibilityPostureTestDB(t)
+
+	posture, err := ResponsibilityPosture(db, uuid.New(), nil)
+	require.NoError(t, err)
+	require.Empty(t, posture)
+}
+
+// TestResponsibilityPostureDefaultsToUnknownWhenNoFilterTargetsIt asserts that every
+// requested responsibility uuid is always present in the returned map — defaulting to
+// "unknown" — even when no filter_responsibilities row targets it at all, matching
+// bulkResolveUpstreamResponsibilities's "never an absent key" convention.
+func TestResponsibilityPostureDefaultsToUnknownWhenNoFilterTargetsIt(t *testing.T) {
+	db := newResponsibilityPostureTestDB(t)
+
+	downstreamSSPID := uuid.New()
+	responsibilityUUID := uuid.New()
+
+	posture, err := ResponsibilityPosture(db, downstreamSSPID, []uuid.UUID{responsibilityUUID})
+	require.NoError(t, err)
+	require.Equal(t, map[uuid.UUID]string{responsibilityUUID: "unknown"}, posture)
+}
+
+// TestResponsibilityPostureIgnoresRowScopedToDifferentSSP asserts that a
+// filter_responsibilities row scoped to a different downstream SSP than the one asked
+// about doesn't affect the result — it stays "unknown" for the requested SSP, since a
+// responsibility's posture is always evaluated per-downstream-SSP (a filter targeting
+// SSP A's leverage of a responsibility says nothing about SSP B's leverage of it).
+func TestResponsibilityPostureIgnoresRowScopedToDifferentSSP(t *testing.T) {
+	db := newResponsibilityPostureTestDB(t)
+
+	responsibilityUUID := uuid.New()
+	otherSSPID := uuid.New()
+	requestedSSPID := uuid.New()
+
+	filterID := uuid.New()
+	require.NoError(t, db.Create(&relational.Filter{
+		UUIDModel: relational.UUIDModel{ID: &filterID},
+		Name:      "other-ssp-filter",
+	}).Error)
+	require.NoError(t, db.Create(&relational.FilterResponsibility{
+		FilterID:           filterID,
+		ResponsibilityUUID: responsibilityUUID,
+		SSPID:              otherSSPID,
+	}).Error)
+
+	posture, err := ResponsibilityPosture(db, requestedSSPID, []uuid.UUID{responsibilityUUID})
+	require.NoError(t, err)
+	require.Equal(t, map[uuid.UUID]string{responsibilityUUID: "unknown"}, posture)
+}

--- a/internal/api/handler/oscal/ssp_leverage.go
+++ b/internal/api/handler/oscal/ssp_leverage.go
@@ -621,6 +621,12 @@ type leveragedControlResponse struct {
 	InheritedFrom               leveragedControlInheritedFrom      `json:"inheritedFrom"`
 	Satisfaction                relational.SSPLeverageSatisfaction `json:"satisfaction"`
 	OutstandingResponsibilities []upstreamResponsibility           `json:"outstandingResponsibilities"`
+	// ResponsibilityPosture is the live, evidence-backed posture (satisfied /
+	// not-satisfied / unknown) per upstream responsibility uuid under this link's
+	// provided-uuid — computed via filter_responsibilities (BCH-1339), independent of
+	// Satisfaction/OutstandingResponsibilities above (which reflect what was attested at
+	// subscribe time, not current evidence).
+	ResponsibilityPosture map[uuid.UUID]string `json:"responsibilityPosture"`
 }
 
 // LeveragedControls godoc
@@ -630,8 +636,10 @@ type leveragedControlResponse struct {
 //	@Description	joined to ssp_leverage_links + the upstream offering. Per control/statement,
 //	@Description	returns which offering it was inherited from, whether satisfaction is full
 //	@Description	or partial (recomputed live from the current satisfied-responsibility rows,
-//	@Description	not trusted from the link's stored value), and any outstanding
-//	@Description	responsibilities. Writes nothing; never touches profile_controls/controls.
+//	@Description	not trusted from the link's stored value), any outstanding
+//	@Description	responsibilities, and live evidence-backed posture per responsibility uuid
+//	@Description	(satisfied/not-satisfied/unknown, via filter_responsibilities). Writes
+//	@Description	nothing; never touches profile_controls/controls.
 //	@Tags			SSP Export Offerings
 //	@Produce		json
 //	@Param			id	path		string	true	"Downstream SSP ID"
@@ -714,10 +722,30 @@ func (h *SSPLeverageHandler) LeveragedControls(ctx echo.Context) error {
 		satisfiedByComponent[s.ByComponentId][s.ResponsibilityUuid] = true
 	}
 
+	// Batch every responsibility uuid under every link's provided-uuid into a single
+	// ResponsibilityPosture call, rather than one call per link.
+	var allResponsibilityUUIDs []uuid.UUID
+	for _, full := range fullSetByProvided {
+		for _, r := range full {
+			allResponsibilityUUIDs = append(allResponsibilityUUIDs, r.ResponsibilityUUID)
+		}
+	}
+	posture, err := ResponsibilityPosture(h.db, sspID, allResponsibilityUUIDs)
+	if err != nil {
+		h.sugar.Errorf("Failed to compute responsibility posture for leverage links: %v", err)
+		return ctx.JSON(http.StatusInternalServerError, api.NewError(err))
+	}
+
 	result := make([]leveragedControlResponse, 0, len(links))
 	for _, link := range links {
 		byComponentID := byComponentIDByInherited[link.InheritedUUID]
-		satisfaction, outstanding := deriveSatisfaction(fullSetByProvided[link.ProvidedUUID], satisfiedByComponent[byComponentID])
+		full := fullSetByProvided[link.ProvidedUUID]
+		satisfaction, outstanding := deriveSatisfaction(full, satisfiedByComponent[byComponentID])
+
+		linkPosture := make(map[uuid.UUID]string, len(full))
+		for _, r := range full {
+			linkPosture[r.ResponsibilityUUID] = posture[r.ResponsibilityUUID]
+		}
 
 		result = append(result, leveragedControlResponse{
 			ControlID:   link.ControlID,
@@ -730,6 +758,7 @@ func (h *SSPLeverageHandler) LeveragedControls(ctx echo.Context) error {
 			},
 			Satisfaction:                satisfaction,
 			OutstandingResponsibilities: outstanding,
+			ResponsibilityPosture:       linkPosture,
 		})
 	}
 

--- a/internal/api/handler/oscal/ssp_leverage_test.go
+++ b/internal/api/handler/oscal/ssp_leverage_test.go
@@ -7,11 +7,14 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
+	"gorm.io/datatypes"
 
 	"github.com/compliance-framework/api/internal/api/handler"
+	"github.com/compliance-framework/api/internal/converters/labelfilter"
 	"github.com/compliance-framework/api/internal/service/relational"
 	"github.com/compliance-framework/api/internal/tests"
 	oscalTypes_1_1_3 "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
@@ -255,4 +258,119 @@ func (suite *SSPLeverageIntegrationSuite) TestSubscribeRequiresSSPUpdateOnDownst
 			"items":                  []map[string]any{{"itemId": createdItem.Data.ID.String(), "satisfiedResponsibilityUuids": []string{respUUID}}},
 		})
 	suite.Require().Equal(http.StatusForbidden, rec.Code, rec.Body.String())
+}
+
+// TestResponsibilityFilterFlipsPosture is BCH-1339's core integration scenario: a
+// filter_responsibilities row targeting respB (the responsibility left outstanding by
+// the subscribe in TestSubscribePartialThenProjection's style flow) drives live,
+// evidence-backed posture on the Inherited Capability projection — independent of the
+// subscribe-time satisfaction/outstandingResponsibilities fields (BCH-1338), and posture
+// flips as newer evidence for the same stream changes status. respA, which has no filter
+// targeting it, stays "unknown" throughout. The SSP-resolution half of AC #1 (matched
+// filter → filter_responsibilities → ssp_leverage_links → downstream SSP) is covered
+// against real Postgres by
+// internal/service/worker's TestRiskEvidenceWorkerResponsibilityIntegrationSuite.
+func (suite *SSPLeverageIntegrationSuite) TestResponsibilityFilterFlipsPosture() {
+	suite.Require().NoError(suite.Migrator.Refresh())
+
+	contributorToken := createRoledUser(&suite.IntegrationTestSuite, "posture-contributor@example.com", "contributor")
+	subscriberToken := createRoledUser(&suite.IntegrationTestSuite, "posture-subscriber@example.com", "ssp-subscriber")
+
+	server := newCedarServer(&suite.IntegrationTestSuite)
+
+	upstreamComponentUUID := uuid.New().String()
+	providedUUID := uuid.New().String()
+	respAUUID := uuid.New().String()
+	respBUUID := uuid.New().String()
+	upstreamSSP := sspWithLeverageableCapability(upstreamComponentUUID, providedUUID, respAUUID, respBUUID)
+	rec := authedRequest(&suite.IntegrationTestSuite, server, "POST", "/api/oscal/system-security-plans", contributorToken, upstreamSSP)
+	suite.Require().Equal(http.StatusCreated, rec.Code, rec.Body.String())
+
+	rec = authedRequest(&suite.IntegrationTestSuite, server, "POST",
+		fmt.Sprintf("/api/oscal/system-security-plans/%s/export-offerings", upstreamSSP.UUID),
+		contributorToken, map[string]string{"title": "Offering"})
+	suite.Require().Equal(http.StatusCreated, rec.Code, rec.Body.String())
+	var createdOffering handler.GenericDataResponse[relational.SSPExportOffering]
+	suite.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &createdOffering))
+	offeringID := createdOffering.Data.ID.String()
+
+	rec = authedRequest(&suite.IntegrationTestSuite, server, "POST",
+		fmt.Sprintf("/api/oscal/system-security-plans/%s/export-offerings/%s/items", upstreamSSP.UUID, offeringID),
+		contributorToken, map[string]any{"controlId": "ac-1", "componentUuid": upstreamComponentUUID, "providedUuid": providedUUID})
+	suite.Require().Equal(http.StatusCreated, rec.Code, rec.Body.String())
+	var createdItem handler.GenericDataResponse[relational.SSPExportOfferingItem]
+	suite.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &createdItem))
+	itemID := createdItem.Data.ID.String()
+
+	rec = authedRequest(&suite.IntegrationTestSuite, server, "POST",
+		fmt.Sprintf("/api/oscal/system-security-plans/%s/export-offerings/%s/publish", upstreamSSP.UUID, offeringID),
+		contributorToken, nil)
+	suite.Require().Equal(http.StatusOK, rec.Code, rec.Body.String())
+
+	downstreamSSP := minimalSSP(uuid.New().String())
+	rec = authedRequest(&suite.IntegrationTestSuite, server, "POST", "/api/oscal/system-security-plans", contributorToken, downstreamSSP)
+	suite.Require().Equal(http.StatusCreated, rec.Code, rec.Body.String())
+
+	rec = authedRequest(&suite.IntegrationTestSuite, server, "POST",
+		"/api/oscal/ssp-export-offerings/"+offeringID+"/subscribe", subscriberToken, map[string]any{
+			"downstreamSspId":        downstreamSSP.UUID,
+			"leveragedAuthorization": map[string]string{"title": "Trust in upstream provider", "partyUuid": uuid.New().String()},
+			"items": []map[string]any{
+				{"itemId": itemID, "satisfiedResponsibilityUuids": []string{respAUUID}},
+			},
+		})
+	suite.Require().Equal(http.StatusCreated, rec.Code, rec.Body.String())
+
+	// A responsibility-targeting filter (BCH-1339) on respB, scoped to the downstream SSP.
+	f := relational.Filter{
+		Name: "respB-filter",
+		Filter: datatypes.NewJSONType(labelfilter.Filter{
+			Scope: &labelfilter.Scope{Condition: &labelfilter.Condition{Label: "resp", Operator: "=", Value: "b"}},
+		}),
+	}
+	suite.Require().NoError(suite.DB.Create(&f).Error)
+	suite.Require().NoError(suite.DB.Create(&relational.FilterResponsibility{
+		FilterID:           *f.ID,
+		ResponsibilityUUID: uuid.MustParse(respBUUID),
+		SSPID:              uuid.MustParse(downstreamSSP.UUID),
+	}).Error)
+
+	now := time.Now().UTC()
+	streamUUID := uuid.New()
+	submitEvidence := func(status string, end time.Time) {
+		evID := uuid.New()
+		suite.Require().NoError(suite.DB.Create(&relational.Evidence{
+			UUIDModel: relational.UUIDModel{ID: &evID},
+			UUID:      streamUUID,
+			Title:     "resp-b-evidence",
+			Start:     now, End: end, Expires: &end,
+			Status: datatypes.NewJSONType(oscalTypes_1_1_3.ObjectiveStatus{State: status, Reason: "auto"}),
+		}).Error)
+		suite.Require().NoError(suite.DB.Exec(
+			"INSERT INTO labels (name, value) VALUES ('resp', 'b') ON CONFLICT DO NOTHING").Error)
+		suite.Require().NoError(suite.DB.Exec(
+			"INSERT INTO evidence_labels (evidence_id, labels_name, labels_value) VALUES (?, 'resp', 'b')", evID).Error)
+	}
+
+	fetchProjection := func() leveragedControlResponse {
+		rec := authedRequest(&suite.IntegrationTestSuite, server, "GET",
+			fmt.Sprintf("/api/oscal/system-security-plans/%s/leveraged-controls", downstreamSSP.UUID), contributorToken, nil)
+		suite.Require().Equal(http.StatusOK, rec.Code, rec.Body.String())
+		var projection handler.GenericDataListResponse[leveragedControlResponse]
+		suite.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &projection))
+		suite.Require().Len(projection.Data, 1)
+		return projection.Data[0]
+	}
+
+	submitEvidence("not-satisfied", now)
+	entry := fetchProjection()
+	suite.Equal("not-satisfied", entry.ResponsibilityPosture[uuid.MustParse(respBUUID)])
+	// respA was satisfied at subscribe time but has no filter targeting it, so its live
+	// posture is "unknown" — independent of the subscribe-time attestation.
+	suite.Equal("unknown", entry.ResponsibilityPosture[uuid.MustParse(respAUUID)])
+
+	// Newer evidence for the same stream flips the posture.
+	submitEvidence("satisfied", now.Add(time.Hour))
+	entry = fetchProjection()
+	suite.Equal("satisfied", entry.ResponsibilityPosture[uuid.MustParse(respBUUID)])
 }

--- a/internal/api/handler/oscal/ssp_leverage_unit_test.go
+++ b/internal/api/handler/oscal/ssp_leverage_unit_test.go
@@ -3,6 +3,7 @@ package oscal
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -40,6 +41,8 @@ func newSSPLeverageTestDB(t *testing.T) *gorm.DB {
 		&relational.InheritedControlImplementation{},
 		&relational.SatisfiedControlImplementationResponsibility{},
 		&relational.LeveragedAuthorization{},
+		&relational.Filter{},
+		&relational.FilterResponsibility{},
 	))
 	return db
 }
@@ -518,5 +521,22 @@ func TestLeveragedControlsProjectionShowsPartialAndOutstanding(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), `"satisfaction":"partial"`)
 	require.Contains(t, rec.Body.String(), fx.respBID.String())
-	require.NotContains(t, rec.Body.String(), fx.respAID.String())
+
+	var parsed struct {
+		Data []leveragedControlResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &parsed))
+	require.Len(t, parsed.Data, 1)
+	// outstandingResponsibilities only ever lists the unsatisfied responsibility (respB) —
+	// that part of the response is unchanged by BCH-1339.
+	require.Len(t, parsed.Data[0].OutstandingResponsibilities, 1)
+	require.Equal(t, fx.respBID, parsed.Data[0].OutstandingResponsibilities[0].ResponsibilityUUID)
+	// responsibilityPosture, by contrast, always covers every upstream responsibility
+	// under the provided-uuid — both respA (satisfied at subscribe time) and respB — since
+	// it's independent, evidence-backed posture, not a subset of what's outstanding.
+	// Neither has a filter targeting it in this test, so both default to "unknown".
+	require.Equal(t, map[uuid.UUID]string{
+		fx.respAID: "unknown",
+		fx.respBID: "unknown",
+	}, parsed.Data[0].ResponsibilityPosture)
 }

--- a/internal/service/migrator.go
+++ b/internal/service/migrator.go
@@ -348,6 +348,31 @@ func MigrateUpWithConfig(db *gorm.DB, cfg *config.Config) error {
 			return err
 		}
 
+		// FilterResponsibility.SSPID (BCH-1339) mirrors filters.ssp_id above: it should
+		// cascade-delete when its downstream SSP is deleted, same as the association
+		// declared in the Go struct (relational.FilterResponsibility.SystemSecurityPlan).
+		if err := db.Exec(`
+			DO $$
+			BEGIN
+			  IF EXISTS (
+			    SELECT 1 FROM information_schema.columns
+			    WHERE table_name = 'filter_responsibilities'
+			      AND column_name = 'ssp_id'
+			  ) AND NOT EXISTS (
+			    SELECT 1 FROM pg_constraint
+			    WHERE conname = 'fk_filter_responsibilities_system_security_plan'
+			  ) THEN
+			    ALTER TABLE filter_responsibilities
+			      ADD CONSTRAINT fk_filter_responsibilities_system_security_plan
+			      FOREIGN KEY (ssp_id)
+			      REFERENCES system_security_plans(id)
+			      ON DELETE CASCADE;
+			  END IF;
+			END $$;
+		`).Error; err != nil {
+			return err
+		}
+
 		if err := db.Exec(`
 			DO $$
 			BEGIN

--- a/internal/service/migrator.go
+++ b/internal/service/migrator.go
@@ -188,6 +188,7 @@ func MigrateUpWithConfig(db *gorm.DB, cfg *config.Config) error {
 		&relational.Labels{},
 		&relational.SelectSubjectById{},
 		&relational.Filter{},
+		&relational.FilterResponsibility{},
 		&suggestionrel.DashboardSuggestionRun{},
 		&suggestionrel.DashboardSuggestionRunCell{},
 		&suggestionrel.DashboardSuggestion{},
@@ -295,6 +296,30 @@ func MigrateUpWithConfig(db *gorm.DB, cfg *config.Config) error {
 			    ALTER TABLE profile_controls
 			      ALTER COLUMN control_catalog_id TYPE uuid
 			      USING NULLIF(control_catalog_id, '')::uuid;
+			  END IF;
+			END $$;
+		`).Error; err != nil {
+			return err
+		}
+
+		// Align control_implementation_responsibilities.provided_uuid (historically text,
+		// since ControlImplementationResponsibility.ProvidedUuid carries no explicit
+		// gorm uuid type tag) with ssp_leverage_links.provided_uuid, which is uuid — the
+		// BCH-1339 filter_responsibilities → ssp_leverage_links resolution arm
+		// (risk_evidence_worker.go) joins these two columns directly. Same idempotent
+		// fix as filter_controls/profile_controls's control_catalog_id above.
+		if err := db.Exec(`
+			DO $$
+			BEGIN
+			  IF EXISTS (
+			    SELECT 1 FROM information_schema.columns
+			    WHERE table_name = 'control_implementation_responsibilities'
+			      AND column_name = 'provided_uuid'
+			      AND data_type = 'text'
+			  ) THEN
+			    ALTER TABLE control_implementation_responsibilities
+			      ALTER COLUMN provided_uuid TYPE uuid
+			      USING NULLIF(provided_uuid, '')::uuid;
 			  END IF;
 			END $$;
 		`).Error; err != nil {
@@ -862,6 +887,7 @@ func MigrateDown(db *gorm.DB) error {
 		&suggestionrel.DashboardSuggestion{},
 		&suggestionrel.DashboardSuggestionRunCell{},
 		&suggestionrel.DashboardSuggestionRun{},
+		&relational.FilterResponsibility{},
 		&relational.Filter{},
 		"filter_controls",
 		"filter_system_components",

--- a/internal/service/relational/filters.go
+++ b/internal/service/relational/filters.go
@@ -17,3 +17,23 @@ type Filter struct {
 
 	SystemSecurityPlan *SystemSecurityPlan `json:"-" gorm:"foreignKey:SSPID;references:ID;constraint:OnDelete:CASCADE"`
 }
+
+// FilterResponsibility links a Filter to a specific upstream
+// ControlImplementationResponsibility uuid, scoped to the downstream SSP whose
+// ssp_leverage_links row it targets (BCH-1339). A sibling of the filter_controls
+// many2many table, not an overload of it: filter_controls has no room for a third
+// column, and the same upstream responsibility (via its provided-uuid) can be leveraged
+// by multiple different downstream SSPs, so SSPID disambiguates which one this row
+// targets — it is the downstream SSP id, matched against
+// ssp_leverage_links.downstream_ssp_id.
+type FilterResponsibility struct {
+	FilterID           uuid.UUID `json:"filterId" gorm:"type:uuid;primaryKey"`
+	ResponsibilityUUID uuid.UUID `json:"responsibilityUuid" gorm:"type:uuid;primaryKey"`
+	SSPID              uuid.UUID `json:"sspId" gorm:"type:uuid;primaryKey"`
+
+	Filter *Filter `json:"-" gorm:"foreignKey:FilterID;references:ID;constraint:OnDelete:CASCADE"`
+}
+
+func (FilterResponsibility) TableName() string {
+	return "filter_responsibilities"
+}

--- a/internal/service/relational/filters.go
+++ b/internal/service/relational/filters.go
@@ -27,11 +27,16 @@ type Filter struct {
 // targets — it is the downstream SSP id, matched against
 // ssp_leverage_links.downstream_ssp_id.
 type FilterResponsibility struct {
-	FilterID           uuid.UUID `json:"filterId" gorm:"type:uuid;primaryKey"`
-	ResponsibilityUUID uuid.UUID `json:"responsibilityUuid" gorm:"type:uuid;primaryKey"`
-	SSPID              uuid.UUID `json:"sspId" gorm:"type:uuid;primaryKey"`
+	FilterID uuid.UUID `json:"filterId" gorm:"type:uuid;primaryKey"`
+	// ResponsibilityUUID and SSPID also carry idx_filter_responsibilities_ssp_lookup, a
+	// composite index leading with ssp_id — the (filter_id, responsibility_uuid, ssp_id)
+	// primary key leads with filter_id, which doesn't serve ResponsibilityPosture's
+	// "WHERE ssp_id = ? AND responsibility_uuid IN ?" lookup (profile_compliance.go).
+	ResponsibilityUUID uuid.UUID `json:"responsibilityUuid" gorm:"type:uuid;primaryKey;index:idx_filter_responsibilities_ssp_lookup,priority:2"`
+	SSPID              uuid.UUID `json:"sspId" gorm:"type:uuid;primaryKey;index:idx_filter_responsibilities_ssp_lookup,priority:1"`
 
-	Filter *Filter `json:"-" gorm:"foreignKey:FilterID;references:ID;constraint:OnDelete:CASCADE"`
+	Filter             *Filter             `json:"-" gorm:"foreignKey:FilterID;references:ID;constraint:OnDelete:CASCADE"`
+	SystemSecurityPlan *SystemSecurityPlan `json:"-" gorm:"foreignKey:SSPID;references:ID;constraint:OnDelete:CASCADE"`
 }
 
 func (FilterResponsibility) TableName() string {

--- a/internal/service/relational/system_security_plan.go
+++ b/internal/service/relational/system_security_plan.go
@@ -1606,12 +1606,17 @@ func (pci *ProvidedControlImplementation) MarshalOscal() *oscalTypes_1_1_3.Provi
 
 type ControlImplementationResponsibility struct {
 	UUIDModel
-	Description      string                    `json:"description"` // required
-	Links            datatypes.JSONSlice[Link] `json:"links"`
-	Props            datatypes.JSONSlice[Prop] `json:"props"`
-	ProvidedUuid     uuid.UUID                 `json:"provided-uuid"`
-	Remarks          string                    `json:"remarks"`
-	ResponsibleRoles []ResponsibleRole         `json:"responsible-roles" gorm:"polymorphic:Parent"`
+	Description string                    `json:"description"` // required
+	Links       datatypes.JSONSlice[Link] `json:"links"`
+	Props       datatypes.JSONSlice[Prop] `json:"props"`
+	// ProvidedUuid is explicitly typed uuid (unlike its historical default, aligned by
+	// migrateAlignProvidedUuidColumnType for pre-existing databases): BCH-1339's
+	// filter_responsibilities → ssp_leverage_links resolution arm
+	// (risk_evidence_worker.go) joins this column directly against
+	// ssp_leverage_links.provided_uuid, which is uuid.
+	ProvidedUuid     uuid.UUID         `json:"provided-uuid" gorm:"type:uuid"`
+	Remarks          string            `json:"remarks"`
+	ResponsibleRoles []ResponsibleRole `json:"responsible-roles" gorm:"polymorphic:Parent"`
 
 	ExportId uuid.UUID
 }

--- a/internal/service/worker/risk_evidence_worker.go
+++ b/internal/service/worker/risk_evidence_worker.go
@@ -139,13 +139,15 @@ func (w *RiskEvidenceWorker) Work(ctx context.Context, job *river.Job[RiskProces
 }
 
 // resolveSSPsViaFilters resolves SSPs by evaluating evidence labels against all filters in-memory,
-// then querying the DB for the filter→control→SSP path.
+// then querying the DB for the filter→control→SSP path (and, for BCH-1339, the
+// filter→responsibility→leverage-link→downstream-SSP path).
 func (w *RiskEvidenceWorker) resolveSSPsViaFilters(ctx context.Context, evidenceLabels []relational.Labels) ([]resolvedSSPInfo, error) {
-	// 1. Load only filters that have at least one control linked (via filter_controls).
-	// Filters without controls can never resolve to an SSP, so loading them is wasteful.
+	// 1. Load only filters that have at least one control or responsibility linked (via
+	// filter_controls or filter_responsibilities). Filters with neither can never resolve
+	// to an SSP, so loading them is wasteful.
 	var filters []relational.Filter
 	if err := w.db.WithContext(ctx).
-		Where("id IN (SELECT DISTINCT filter_id FROM filter_controls)").
+		Where("id IN (SELECT DISTINCT filter_id FROM filter_controls) OR id IN (SELECT DISTINCT filter_id FROM filter_responsibilities)").
 		Find(&filters).Error; err != nil {
 		return nil, fmt.Errorf("failed to load filters: %w", err)
 	}
@@ -222,10 +224,6 @@ func (w *RiskEvidenceWorker) resolveSSPsViaFilters(ctx context.Context, evidence
 		return nil, fmt.Errorf("failed to query SSPs via filter controls: %w", err)
 	}
 
-	if len(rows) == 0 {
-		return nil, nil
-	}
-
 	// 5. Group by SSP ID
 	sspMap := make(map[uuid.UUID]*resolvedSSPInfo)
 	for _, row := range rows {
@@ -238,6 +236,49 @@ func (w *RiskEvidenceWorker) resolveSSPsViaFilters(ctx context.Context, evidence
 			CatalogID: row.ControlCatalogID,
 			ControlID: row.ControlID,
 		})
+	}
+
+	// 6. Query filter_responsibilities → ssp_leverage_links to resolve downstream SSPs
+	// leveraging a responsibility a matched filter targets (BCH-1339). The two-hop lookup
+	// (filter_responsibilities.responsibility_uuid → its provided_uuid via
+	// control_implementation_responsibilities → the downstream leverage link) mirrors the
+	// one already used in internal/api/handler/oscal/ssp_leverage.go's
+	// bulkResolveUpstreamResponsibilities, but in reverse: there we start from a
+	// provided-uuid and find responsibilities; here we start from a responsibility-uuid
+	// and find its provided-uuid. filter_responsibilities.ssp_id must match the leverage
+	// link's own downstream_ssp_id: the same upstream provided-uuid can be leveraged by
+	// several different downstream SSPs, and ssp_id is what picks the right one.
+	// Unlike the control arm, there's no catalog control being targeted here, so resolved
+	// SSPs get no ControlLinks — createRiskLinks already treats that as optional.
+	type filterResponsibilityRow struct {
+		SystemSecurityPlanID uuid.UUID `gorm:"column:system_security_plan_id"`
+	}
+
+	var responsibilityRows []filterResponsibilityRow
+	if err := w.db.WithContext(ctx).
+		Table("filter_responsibilities fr").
+		Select("DISTINCT sll.downstream_ssp_id AS system_security_plan_id").
+		Joins("JOIN control_implementation_responsibilities cir ON cir.id = fr.responsibility_uuid").
+		// Direct (uncast) equality: both sides are uuid on Postgres (cir.provided_uuid's
+		// column type is aligned by the migrateAlignProvidedUuidColumnType data migration,
+		// the same fix already applied to filter_controls.control_catalog_id), text=text
+		// on the sqlite unit-test DB. CAST(... AS uuid) would coerce sqlite's text uuids to
+		// 0 via NUMERIC affinity and cross-join — the same trap the filter_controls arm
+		// above avoids for exactly this reason.
+		Joins("JOIN ssp_leverage_links sll ON sll.provided_uuid = cir.provided_uuid AND sll.downstream_ssp_id = fr.ssp_id").
+		Where("fr.filter_id IN ?", matchingFilterIDs).
+		Scan(&responsibilityRows).Error; err != nil {
+		return nil, fmt.Errorf("failed to query SSPs via filter responsibilities: %w", err)
+	}
+
+	for _, row := range responsibilityRows {
+		if _, exists := sspMap[row.SystemSecurityPlanID]; !exists {
+			sspMap[row.SystemSecurityPlanID] = &resolvedSSPInfo{SSPID: row.SystemSecurityPlanID}
+		}
+	}
+
+	if len(sspMap) == 0 {
+		return nil, nil
 	}
 
 	result := make([]resolvedSSPInfo, 0, len(sspMap))

--- a/internal/service/worker/risk_evidence_worker_responsibility_integration_test.go
+++ b/internal/service/worker/risk_evidence_worker_responsibility_integration_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/compliance-framework/api/internal/converters/labelfilter"
+	"github.com/compliance-framework/api/internal/service/relational"
+	"github.com/compliance-framework/api/internal/tests"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+	"gorm.io/datatypes"
+)
+
+// RiskEvidenceWorkerResponsibilityIntegrationSuite exercises resolveSSPsViaFilters's
+// BCH-1339 second arm (filter_responsibilities → ssp_leverage_links) against real
+// Postgres, complementing the sqlite unit tests in risk_evidence_worker_test.go — in
+// particular the uuid column types and casing that only a real Postgres schema exercises.
+type RiskEvidenceWorkerResponsibilityIntegrationSuite struct {
+	tests.IntegrationTestSuite
+}
+
+func TestRiskEvidenceWorkerResponsibilityIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(RiskEvidenceWorkerResponsibilityIntegrationSuite))
+}
+
+func (suite *RiskEvidenceWorkerResponsibilityIntegrationSuite) SetupTest() {
+	suite.Require().NoError(suite.Migrator.Refresh())
+}
+
+// seedLeveragedResponsibility creates the minimal real-schema graph a
+// filter_responsibilities → ssp_leverage_links resolution needs: an Export with one
+// ProvidedControlImplementation and one ControlImplementationResponsibility under it, a
+// downstream SystemSecurityPlan, and an SSPLeverageLink tying the two together. Returns
+// the responsibility uuid and the downstream SSP id.
+func (suite *RiskEvidenceWorkerResponsibilityIntegrationSuite) seedLeveragedResponsibility() (responsibilityUUID uuid.UUID, downstreamSSPID uuid.UUID) {
+	export := relational.Export{}
+	suite.Require().NoError(suite.DB.Create(&export).Error)
+
+	provided := relational.ProvidedControlImplementation{ExportId: *export.ID, Description: "provided"}
+	suite.Require().NoError(suite.DB.Create(&provided).Error)
+
+	responsibility := relational.ControlImplementationResponsibility{
+		ExportId: *export.ID, ProvidedUuid: *provided.ID, Description: "responsibility",
+	}
+	suite.Require().NoError(suite.DB.Create(&responsibility).Error)
+
+	upstreamSSP := relational.SystemSecurityPlan{}
+	suite.Require().NoError(suite.DB.Create(&upstreamSSP).Error)
+
+	downstreamSSP := relational.SystemSecurityPlan{}
+	suite.Require().NoError(suite.DB.Create(&downstreamSSP).Error)
+
+	link := relational.SSPLeverageLink{
+		DownstreamSSPID:   *downstreamSSP.ID,
+		UpstreamSSPID:     *upstreamSSP.ID,
+		OfferingID:        uuid.New(),
+		ControlID:         "ac-1",
+		ProvidedUUID:      *provided.ID,
+		InheritedUUID:     uuid.New(),
+		LeveragedAuthUUID: uuid.New(),
+		Satisfaction:      relational.SSPLeverageSatisfactionPartial,
+		Status:            relational.SSPLeverageStatusActive,
+	}
+	suite.Require().NoError(suite.DB.Create(&link).Error)
+
+	return *responsibility.ID, *downstreamSSP.ID
+}
+
+func (suite *RiskEvidenceWorkerResponsibilityIntegrationSuite) seedResponsibilityFilter(downstreamSSPID, responsibilityUUID uuid.UUID, labelKey, labelValue string) {
+	filterScope := labelfilter.Filter{
+		Scope: &labelfilter.Scope{
+			Condition: &labelfilter.Condition{Label: labelKey, Operator: "=", Value: labelValue},
+		},
+	}
+	f := relational.Filter{Name: "responsibility-filter", Filter: datatypes.NewJSONType(filterScope)}
+	suite.Require().NoError(suite.DB.Create(&f).Error)
+	suite.Require().NoError(suite.DB.Create(&relational.FilterResponsibility{
+		FilterID:           *f.ID,
+		ResponsibilityUUID: responsibilityUUID,
+		SSPID:              downstreamSSPID,
+	}).Error)
+}
+
+func (suite *RiskEvidenceWorkerResponsibilityIntegrationSuite) TestResolvesDownstreamSSPViaFilterResponsibilities() {
+	responsibilityUUID, downstreamSSPID := suite.seedLeveragedResponsibility()
+	suite.seedResponsibilityFilter(downstreamSSPID, responsibilityUUID, "environment", "production")
+
+	worker := NewRiskEvidenceWorker(suite.DB, zap.NewNop().Sugar())
+	sspInfos, err := worker.resolveSSPsViaFilters(context.Background(), []relational.Labels{
+		{Name: "environment", Value: "production"},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(sspInfos, 1)
+	suite.Equal(downstreamSSPID, sspInfos[0].SSPID)
+	suite.Empty(sspInfos[0].ControlLinks)
+}
+
+func (suite *RiskEvidenceWorkerResponsibilityIntegrationSuite) TestNoMatchReturnsNoSSPs() {
+	responsibilityUUID, downstreamSSPID := suite.seedLeveragedResponsibility()
+	suite.seedResponsibilityFilter(downstreamSSPID, responsibilityUUID, "environment", "staging")
+
+	worker := NewRiskEvidenceWorker(suite.DB, zap.NewNop().Sugar())
+	sspInfos, err := worker.resolveSSPsViaFilters(context.Background(), []relational.Labels{
+		{Name: "environment", Value: "production"},
+	})
+	suite.Require().NoError(err)
+	suite.Empty(sspInfos)
+}

--- a/internal/service/worker/risk_evidence_worker_test.go
+++ b/internal/service/worker/risk_evidence_worker_test.go
@@ -95,6 +95,27 @@ func newRiskEvidenceWorkerTestDB(t *testing.T) *gorm.DB {
 		PRIMARY KEY (system_security_plan_id, profile_id)
 	)`).Error)
 
+	// BCH-1339: minimal tables for the filter_responsibilities → ssp_leverage_links
+	// resolution arm. Only the columns resolveSSPsViaFilters actually joins on are
+	// included, matching the minimal-table style already used above for filter_controls.
+	require.NoError(t, db.Exec(`CREATE TABLE IF NOT EXISTS filter_responsibilities (
+		filter_id TEXT,
+		responsibility_uuid TEXT,
+		ssp_id TEXT,
+		PRIMARY KEY (filter_id, responsibility_uuid, ssp_id)
+	)`).Error)
+
+	require.NoError(t, db.Exec(`CREATE TABLE IF NOT EXISTS control_implementation_responsibilities (
+		id TEXT PRIMARY KEY,
+		provided_uuid TEXT
+	)`).Error)
+
+	require.NoError(t, db.Exec(`CREATE TABLE IF NOT EXISTS ssp_leverage_links (
+		id TEXT PRIMARY KEY,
+		downstream_ssp_id TEXT,
+		provided_uuid TEXT
+	)`).Error)
+
 	return db
 }
 
@@ -224,6 +245,46 @@ func seedScopedFilterForControl(t *testing.T, db *gorm.DB, sspID *uuid.UUID, con
 	require.NoError(t, db.Exec(
 		`INSERT INTO filter_controls (filter_id, control_catalog_id, control_id) VALUES (?, ?, ?)`,
 		filterID.String(), controlCatalogID.String(), controlID,
+	).Error)
+
+	return filterID
+}
+
+// seedFilterForResponsibility creates a filter matching labelKey=labelValue and links it to
+// responsibilityUUID, scoped to downstreamSSPID, via filter_responsibilities. Also seeds the
+// minimal control_implementation_responsibilities row (responsibilityUUID → providedUUID) and
+// ssp_leverage_links row (downstreamSSPID + providedUUID) needed for the join in
+// resolveSSPsViaFilters's second arm to resolve. Returns the filter id.
+func seedFilterForResponsibility(t *testing.T, db *gorm.DB, downstreamSSPID, responsibilityUUID, providedUUID uuid.UUID, labelKey, labelValue string) uuid.UUID {
+	t.Helper()
+	filterID := uuid.New()
+
+	filterScope := labelfilter.Filter{
+		Scope: &labelfilter.Scope{
+			Condition: &labelfilter.Condition{Label: labelKey, Operator: "=", Value: labelValue},
+		},
+	}
+	filterJSON, err := json.Marshal(filterScope)
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO filters (id, name, filter) VALUES (?, ?, ?)`,
+		filterID.String(), "test-responsibility-filter", string(filterJSON),
+	).Error)
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO filter_responsibilities (filter_id, responsibility_uuid, ssp_id) VALUES (?, ?, ?)`,
+		filterID.String(), responsibilityUUID.String(), downstreamSSPID.String(),
+	).Error)
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO control_implementation_responsibilities (id, provided_uuid) VALUES (?, ?)`,
+		responsibilityUUID.String(), providedUUID.String(),
+	).Error)
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO ssp_leverage_links (id, downstream_ssp_id, provided_uuid) VALUES (?, ?, ?)`,
+		uuid.New().String(), downstreamSSPID.String(), providedUUID.String(),
 	).Error)
 
 	return filterID
@@ -1791,6 +1852,135 @@ func TestRiskEvidenceWorker_resolveSSPsViaFilters_MultipleSSPs(t *testing.T) {
 	}
 	assert.True(t, sspIDs[*ssp1.ID])
 	assert.True(t, sspIDs[*ssp2.ID])
+}
+
+func TestRiskEvidenceWorker_resolveSSPsViaFilters_ResolvesViaFilterResponsibilities(t *testing.T) {
+	t.Parallel()
+
+	worker := createTestRiskEvidenceWorker(t)
+	ctx := context.Background()
+
+	downstreamSSPID := uuid.New()
+	responsibilityUUID := uuid.New()
+	providedUUID := uuid.New()
+
+	// This filter has no filter_controls row at all — only filter_responsibilities — so
+	// it exercises both the updated filter-load query (task 002) and the new arm.
+	seedFilterForResponsibility(t, worker.db, downstreamSSPID, responsibilityUUID, providedUUID, "environment", "production")
+
+	labels := []relational.Labels{
+		{Name: "environment", Value: "production"},
+	}
+
+	sspInfos, err := worker.resolveSSPsViaFilters(ctx, labels)
+	require.NoError(t, err)
+	require.Len(t, sspInfos, 1)
+	assert.Equal(t, downstreamSSPID, sspInfos[0].SSPID)
+	assert.Empty(t, sspInfos[0].ControlLinks)
+}
+
+func TestRiskEvidenceWorker_resolveSSPsViaFilters_ResponsibilityLeveragedByMultipleSSPs(t *testing.T) {
+	t.Parallel()
+
+	worker := createTestRiskEvidenceWorker(t)
+	ctx := context.Background()
+
+	// Two different downstream SSPs both leverage the same upstream responsibility (and
+	// its provided_uuid — a single, real upstream row), each via its own filter scoped to
+	// its own ssp_id. seedFilterForResponsibility seeds the shared
+	// control_implementation_responsibilities row itself, so it can only be called once
+	// per responsibilityUUID; the second SSP's filter + leverage link are seeded directly.
+	providedUUID := uuid.New()
+	responsibilityUUID := uuid.New()
+	downstreamSSP1 := uuid.New()
+	downstreamSSP2 := uuid.New()
+
+	seedFilterForResponsibility(t, worker.db, downstreamSSP1, responsibilityUUID, providedUUID, "environment", "production")
+
+	filter2ID := uuid.New()
+	filterScope := labelfilter.Filter{
+		Scope: &labelfilter.Scope{
+			Condition: &labelfilter.Condition{Label: "environment", Operator: "=", Value: "production"},
+		},
+	}
+	filterJSON, err := json.Marshal(filterScope)
+	require.NoError(t, err)
+	require.NoError(t, worker.db.Exec(
+		`INSERT INTO filters (id, name, filter) VALUES (?, ?, ?)`,
+		filter2ID.String(), "second-downstream-filter", string(filterJSON),
+	).Error)
+	require.NoError(t, worker.db.Exec(
+		`INSERT INTO filter_responsibilities (filter_id, responsibility_uuid, ssp_id) VALUES (?, ?, ?)`,
+		filter2ID.String(), responsibilityUUID.String(), downstreamSSP2.String(),
+	).Error)
+	require.NoError(t, worker.db.Exec(
+		`INSERT INTO ssp_leverage_links (id, downstream_ssp_id, provided_uuid) VALUES (?, ?, ?)`,
+		uuid.New().String(), downstreamSSP2.String(), providedUUID.String(),
+	).Error)
+
+	labels := []relational.Labels{
+		{Name: "environment", Value: "production"},
+	}
+
+	sspInfos, err := worker.resolveSSPsViaFilters(ctx, labels)
+	require.NoError(t, err)
+	require.Len(t, sspInfos, 2)
+
+	sspIDs := make(map[uuid.UUID]bool)
+	for _, info := range sspInfos {
+		sspIDs[info.SSPID] = true
+	}
+	assert.True(t, sspIDs[downstreamSSP1])
+	assert.True(t, sspIDs[downstreamSSP2])
+}
+
+func TestRiskEvidenceWorker_resolveSSPsViaFilters_ResponsibilityWrongSSPScopeDoesNotResolve(t *testing.T) {
+	t.Parallel()
+
+	worker := createTestRiskEvidenceWorker(t)
+	ctx := context.Background()
+
+	// filter_responsibilities.ssp_id names a downstream SSP that has no matching
+	// ssp_leverage_links row for this provided_uuid (a leverage link exists, but for a
+	// different downstream SSP) — the join must not resolve anything.
+	providedUUID := uuid.New()
+	responsibilityUUID := uuid.New()
+	scopedSSPID := uuid.New()
+	actualLeveragingSSPID := uuid.New()
+
+	filterID := uuid.New()
+	filterScope := labelfilter.Filter{
+		Scope: &labelfilter.Scope{
+			Condition: &labelfilter.Condition{Label: "environment", Operator: "=", Value: "production"},
+		},
+	}
+	filterJSON, err := json.Marshal(filterScope)
+	require.NoError(t, err)
+	require.NoError(t, worker.db.Exec(
+		`INSERT INTO filters (id, name, filter) VALUES (?, ?, ?)`,
+		filterID.String(), "mis-scoped-filter", string(filterJSON),
+	).Error)
+	require.NoError(t, worker.db.Exec(
+		`INSERT INTO filter_responsibilities (filter_id, responsibility_uuid, ssp_id) VALUES (?, ?, ?)`,
+		filterID.String(), responsibilityUUID.String(), scopedSSPID.String(),
+	).Error)
+	require.NoError(t, worker.db.Exec(
+		`INSERT INTO control_implementation_responsibilities (id, provided_uuid) VALUES (?, ?)`,
+		responsibilityUUID.String(), providedUUID.String(),
+	).Error)
+	// Leverage link exists, but for a different downstream SSP than the filter names.
+	require.NoError(t, worker.db.Exec(
+		`INSERT INTO ssp_leverage_links (id, downstream_ssp_id, provided_uuid) VALUES (?, ?, ?)`,
+		uuid.New().String(), actualLeveragingSSPID.String(), providedUUID.String(),
+	).Error)
+
+	labels := []relational.Labels{
+		{Name: "environment", Value: "production"},
+	}
+
+	sspInfos, err := worker.resolveSSPsViaFilters(ctx, labels)
+	require.NoError(t, err)
+	assert.Empty(t, sspInfos)
 }
 
 func TestComputeDedupeKeyForSSP_WithDedupeLabelKeys(t *testing.T) {

--- a/internal/tests/migrate.go
+++ b/internal/tests/migrate.go
@@ -193,6 +193,7 @@ func (t *TestMigrator) Up() error {
 		&relational.Labels{},
 		&relational.SelectSubjectById{},
 		&relational.Filter{},
+		&relational.FilterResponsibility{},
 		&suggestionrel.DashboardSuggestionRun{},
 		&suggestionrel.DashboardSuggestionRunCell{},
 		&suggestionrel.DashboardSuggestion{},
@@ -570,6 +571,7 @@ func (t *TestMigrator) Down() error {
 		&suggestionrel.DashboardSuggestion{},
 		&suggestionrel.DashboardSuggestionRunCell{},
 		&suggestionrel.DashboardSuggestionRun{},
+		&relational.FilterResponsibility{},
 		&relational.Filter{},
 	)
 }


### PR DESCRIPTION
## Summary
Phase 3 of Cross-SSP Control Export/Import: lets a downstream customer-responsibility be a first-class compliance target with its own filter → evidence → posture, without minting a synthetic catalog control. Depends on Phase 2 (#447, merged).

- New `filter_responsibilities` join table (`filter_id`, `responsibility_uuid`, `ssp_id`) — a sibling of `filter_controls`, not an overload of it.
- `resolveSSPsViaFilters` (risk evidence worker) gains a second resolution path: matched filter → `filter_responsibilities` → `ssp_leverage_links` → downstream SSP.
- New `ResponsibilityPosture` function computes per-responsibility posture (satisfied / not-satisfied / unknown) from matched evidence, using the same status-count logic as control-keyed posture, and feeds it into the Inherited Capability projection (`LeveragedControls`'s `responsibilityPosture` field).
- Fixes a latent schema issue the new join exposed: `ControlImplementationResponsibility.ProvidedUuid` had no explicit `uuid` column type, causing a real `uuid = text` failure against Postgres. Fixed with the same tag + idempotent `ALTER COLUMN` pattern already used for `filter_controls.control_catalog_id`.

## Test plan
- [x] Unit tests (sqlite): resolution-arm coverage in `risk_evidence_worker_test.go`, posture-default coverage in `profile_compliance_unit_test.go`, wiring coverage in `ssp_leverage_unit_test.go`.
- [x] Integration tests (real Postgres via testcontainers): `TestRiskEvidenceWorkerResponsibilityIntegrationSuite` (SSP resolution) and `TestResponsibilityFilterFlipsPosture` (posture flip against live evidence).
- [x] Regression: all pre-existing `filter_controls`/`ComplianceProgress` tests pass unmodified.
- [x] `make reviewable` (swag + lint + full integration suite) passes clean.

## Out of scope
Risk generation (Phase 4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Leveraged controls responses now include live responsibility posture for each responsibility UUID.
  * Responsibility status is computed from current evidence and can show `satisfied`, `not-satisfied`, or `unknown`.
* **Bug Fixes**
  * Satisfaction is now recomputed from live data instead of relying on stored values.
  * Filters tied to responsibilities now resolve downstream SSPs correctly, even without control-based matches.
* **Tests**
  * Added coverage for responsibility posture calculations and downstream SSP resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->